### PR TITLE
refactor: split code examples into smaller topics

### DIFF
--- a/src/data/go-cheatsheet/basic-types.json
+++ b/src/data/go-cheatsheet/basic-types.json
@@ -2,20 +2,72 @@
   "title": "Basic Types",
   "codeExamples": [
     {
-      "title": "Numeric",
-      "code": "// 整数型\n// プラットフォーム依存 (32 or 64 bit)\nvar i int = 42\n// プラットフォーム依存 (32 or 64 bit)\nvar u uint = 42\n// -128 to 127\nvar i8 int8 = 127\n// -32768 to 32767\nvar i16 int16 = 32767\nvar i32 int32 = 2147483647\nvar i64 int64 = 9223372036854775807\n// int32 のエイリアス、Unicode コードポイントを表す\nvar rune = 'a'\n\n// 符号なし整数\n// 0 to 255\nvar u8 uint8 = 255\n// 0 to 65535\nvar u16 uint16 = 65535\n// uint8 のエイリアス\nvar byte = 255\n\n// 浮動小数点数型\nvar f32 float32 = 3.14\n// IEEE-754 64-bit\nvar f64 float64 = 3.14159265359\n\n// 複素数型\nvar c64 complex64 = 1 + 2i\nvar c128 complex128 = complex(3.5, 4.2)"
+      "title": "Integer Types",
+      "code": "// 整数型\n// プラットフォーム依存 (32 or 64 bit)\nvar i int = 42\n// プラットフォーム依存 (32 or 64 bit)\nvar u uint = 42\n// -128 to 127\nvar i8 int8 = 127\n// -32768 to 32767\nvar i16 int16 = 32767\nvar i32 int32 = 2147483647\nvar i64 int64 = 9223372036854775807\n// int32 のエイリアス、Unicode コードポイントを表す\nvar rune = 'a'"
     },
     {
-      "title": "String",
-      "code": "// 文字列宣言 (不変のバイトシーケンス)\nvar str string = \"hello\"\n\n// 生文字列リテラル (改行を保持、エスケープなし)\nmultiline := `This is a\nmultiline string\nwith \"quotes\" intact`\n\n// 文字列操作\ns := \"hello\"\n// 長さ: 5 (bytes, not runes)\nlen := len(s)\n// byte: 101 ('e')\nchar := s[1]\n// \"el\"\nsubstr := s[1:3]\n\n// 文字列連結\ns1 := \"hello\"\ns2 := \"world\"\n// \"hello world\"\ncombined := s1 + \" \" + s2\n\n// UTF-8 と Unicode\n// UTF-8 エンコードされた文字列\ns := \"Hello, 世界\"\n// Unicode コードポイントに変換\nrunes := []rune(s)\nfor i, r := range s {\n// rune とそのバイト位置を出力\n  fmt.Printf(\"%d: %c\\n\", i, r)\n}"
+      "title": "Unsigned Integer Types",
+      "code": "// 符号なし整数\n// 0 to 255\nvar u8 uint8 = 255\n// 0 to 65535\nvar u16 uint16 = 65535\n// uint8 のエイリアス\nvar byte = 255"
     },
     {
-      "title": "Boolean",
-      "code": "// 真偽値\nvar isTrue bool = true\nvar isFalse bool = false\n\n// ゼロ値は false\n// false\nvar initialized bool\n\n// 真偽値演算\n// false (AND)\nresult := isTrue && isFalse\n// true (OR)\nresult = isTrue || isFalse\n// false (NOT)\nresult = !isTrue\n\n// 条件評価\nif isTrue {\n  // isTrue が true の場合に実行される\n}\n\n// 短絡評価\nif isValid() && doSomething() {\n  // doSomething() は isValid() が true を返す場合のみ呼び出される\n}"
+      "title": "Floating-Point Types",
+      "code": "// 浮動小数点数型\nvar f32 float32 = 3.14\n// IEEE-754 64-bit\nvar f64 float64 = 3.14159265359"
     },
     {
-      "title": "Type Conversions",
-      "code": "// Go は明示的な型変換が必要\nvar i int = 42\n// int から float への変換\nvar f float64 = float64(i)\n// float から uint への変換\nvar u uint = uint(f)\n\n// 文字列変換\n// int to string: \"42\"\ns := strconv.Itoa(i)\n// string to int: 42, nil\ni, err := strconv.Atoi(s)\n\n// その他の文字列変換\n// string から byte スライスへ\nb := []byte(\"hello\")\n// byte スライスから string へ\ns := string(b)\n\n// 数値文字列のパース\n// string to float64\nf, err := strconv.ParseFloat(\"3.14\", 64)\n// string to int64 (base 10)\ni, err := strconv.ParseInt(\"-42\", 10, 64)\n// string to uint64 (base 10)\nu, err := strconv.ParseUint(\"42\", 10, 64)\n\n// 値を文字列としてフォーマット\n// \"true\"\ns := strconv.FormatBool(true)\n// \"3.14\" (2 decimal places)\ns := strconv.FormatFloat(3.14, 'f', 2, 64)\n// \"-42\" (base 10)\ns := strconv.FormatInt(-42, 10)"
+      "title": "Complex Types",
+      "code": "// 複素数型\nvar c64 complex64 = 1 + 2i\nvar c128 complex128 = complex(3.5, 4.2)"
+    },
+    {
+      "title": "String Declaration",
+      "code": "// 文字列宣言 (不変のバイトシーケンス)\nvar str string = \"hello\""
+    },
+    {
+      "title": "Raw String Literals",
+      "code": "// 生文字列リテラル (改行を保持、エスケープなし)\nmultiline := `This is a\nmultiline string\nwith \"quotes\" intact`"
+    },
+    {
+      "title": "Basic String Operations",
+      "code": "// 文字列操作\ns := \"hello\"\n// 長さ: 5 (bytes, not runes)\nlen := len(s)\n// byte: 101 ('e')\nchar := s[1]\n// \"el\"\nsubstr := s[1:3]"
+    },
+    {
+      "title": "String Concatenation",
+      "code": "// 文字列連結\ns1 := \"hello\"\ns2 := \"world\"\n// \"hello world\"\ncombined := s1 + \" \" + s2"
+    },
+    {
+      "title": "Strings and UTF-8/Runes",
+      "code": "// UTF-8 と Unicode\n// UTF-8 エンコードされた文字列\ns := \"Hello, 世界\"\n// Unicode コードポイントに変換\nrunes := []rune(s)\nfor i, r := range s {\n// rune とそのバイト位置を出力\n  fmt.Printf(\"%d: %c\\n\", i, r)\n}"
+    },
+    {
+      "title": "Boolean Declaration",
+      "code": "// 真偽値\nvar isTrue bool = true\nvar isFalse bool = false\n\n// ゼロ値は false\n// false\nvar initialized bool"
+    },
+    {
+      "title": "Boolean Operations",
+      "code": "// 真偽値演算\n// false (AND)\nresult := isTrue && isFalse\n// true (OR)\nresult = isTrue || isFalse\n// false (NOT)\nresult = !isTrue"
+    },
+    {
+      "title": "Boolean Evaluation",
+      "code": "// 条件評価\nif isTrue {\n  // isTrue が true の場合に実行される\n}\n\n// 短絡評価\nif isValid() && doSomething() {\n  // doSomething() は isValid() が true を返す場合のみ呼び出される\n}"
+    },
+    {
+      "title": "Explicit Numeric Conversions",
+      "code": "// Go は明示的な型変換が必要\nvar i int = 42\n// int から float への変換\nvar f float64 = float64(i)\n// float から uint への変換\nvar u uint = uint(f)"
+    },
+    {
+      "title": "String Conversions (Itoa/Atoi)",
+      "code": "// 文字列変換\n// int to string: \"42\"\ns := strconv.Itoa(i)\n// string to int: 42, nil\ni, err := strconv.Atoi(s)"
+    },
+    {
+      "title": "String/Byte Slice Conversions",
+      "code": "// その他の文字列変換\n// string から byte スライスへ\nb := []byte(\"hello\")\n// byte スライスから string へ\ns := string(b)"
+    },
+    {
+      "title": "Parsing Numeric Strings",
+      "code": "// 数値文字列のパース\n// string to float64\nf, err := strconv.ParseFloat(\"3.14\", 64)\n// string to int64 (base 10)\ni, err := strconv.ParseInt(\"-42\", 10, 64)\n// string to uint64 (base 10)\nu, err := strconv.ParseUint(\"42\", 10, 64)"
+    },
+    {
+      "title": "Formatting Values as Strings",
+      "code": "// 値を文字列としてフォーマット\n// \"true\"\ns := strconv.FormatBool(true)\n// \"3.14\" (2 decimal places)\ns := strconv.FormatFloat(3.14, 'f', 2, 64)\n// \"-42\" (base 10)\ns := strconv.FormatInt(-42, 10)"
     },
     {
       "title": "Zero Values",

--- a/src/data/go-cheatsheet/basics.json
+++ b/src/data/go-cheatsheet/basics.json
@@ -6,20 +6,72 @@
       "code": "package main\n\nimport \"fmt\"\n\nfunc main() {\n  fmt.Println(\"Hello, World!\")\n}"
     },
     {
-      "title": "Variables",
-      "code": "// 変数宣言\nvar name string = \"Go\"\n\n// 短い変数宣言\nage := 10\n\n// 複数の変数\nvar (\n  a, b int\n  c    string\n)\n\n// 変数の初期化\nvar (\n  home = os.Getenv(\"HOME\")\n  user = os.Getenv(\"USER\")\n)\n\n// 未使用の変数はエラーを引き起こす\n// 値を無視するには _ (ブランク識別子) を使用する\n_, err := fmt.Println(\"Hello\")"
+      "title": "Variable Declaration",
+      "code": "// 変数宣言\nvar name string = \"Go\""
     },
     {
-      "title": "Constants",
-      "code": "// 定数宣言\nconst Pi = 3.14\n\n// 複数の定数\nconst (\n  StatusOK    = 200\n  StatusError = 500\n)\n\n// iota - 列挙型ジェネレータ\nconst (\n// 1\n  Monday = iota + 1\n// 2\n  Tuesday\n// 3\n  Wednesday\n)\n\n// iota は新しい const ブロックでリセットされる\nconst (\n// 1 (1 << 0)\n  Readable = 1 << iota\n// 2 (1 << 1)\n  Writable\n// 4 (1 << 2)\n  Executable\n  \n  // パーミッションの組み合わせ\n// 3\n  ReadWrite = Readable | Writable\n)"
+      "title": "Short Variable Declaration",
+      "code": "// 短い変数宣言\nage := 10"
     },
     {
-      "title": "Naming Conventions",
-      "code": "// パッケージ名は小文字の単一単語\npackage http\n\n// エクスポートされる識別子には CamelCase (パッケージ外から見える)\ntype Customer struct{}\nfunc WriteFile() {}\nvar MaxLength int\n\n// エクスポートされない識別子には camelCase (パッケージ内プライベート)\ntype httpClient struct{}\nfunc writeLog() {}\nvar maxRetries int\n\n// 頭字語は識別子内ですべて大文字\n// e.g., HTTP, URL, ID\nvar userID string\nfunc parseHTTPResponse() {}\n\n// 単一メソッドのインターフェースは -er で終わる\ntype Reader interface {\n  Read(p []byte) (n int, err error)\n}"
+      "title": "Multiple Variables",
+      "code": "// 複数の変数\nvar (\n  a, b int\n  c    string\n)"
     },
     {
-      "title": "Code Organization",
-      "code": "// Go のコードはパッケージに整理される\n// 各ディレクトリはパッケージ\n// main パッケージは実行可能ファイルの入口\npackage main\n\n// インポートはグループ化され、ファクタリングできる\nimport (\n  \"fmt\"\n  \"io\"\n  \n// サードパーティパッケージ\n  \"golang.org/x/net/html\"\n// ローカルパッケージ\n  \"myproject/mypackage\"\n)\n\n// 一般的な Go ファイルの構造:\n// 1. パッケージ宣言\n// 2. インポート\n// 3. 定数\n// 4. 変数\n// 5. 型\n// 6. 関数"
+      "title": "Variable Initialization",
+      "code": "// 変数の初期化\nvar (\n  home = os.Getenv(\"HOME\")\n  user = os.Getenv(\"USER\")\n)"
+    },
+    {
+      "title": "Blank Identifier (_)",
+      "code": "// 未使用の変数はエラーを引き起こす\n// 値を無視するには _ (ブランク識別子) を使用する\n_, err := fmt.Println(\"Hello\")"
+    },
+    {
+      "title": "Constant Declaration",
+      "code": "// 定数宣言\nconst Pi = 3.14"
+    },
+    {
+      "title": "Multiple Constants",
+      "code": "// 複数の定数\nconst (\n  StatusOK    = 200\n  StatusError = 500\n)"
+    },
+    {
+      "title": "iota for Enumeration",
+      "code": "// iota - 列挙型ジェネレータ\nconst (\n// 1\n  Monday = iota + 1\n// 2\n  Tuesday\n// 3\n  Wednesday\n)"
+    },
+    {
+      "title": "iota for Bit Flags",
+      "code": "// iota は新しい const ブロックでリセットされる\nconst (\n// 1 (1 << 0)\n  Readable = 1 << iota\n// 2 (1 << 1)\n  Writable\n// 4 (1 << 2)\n  Executable\n  \n  // パーミッションの組み合わせ\n// 3\n  ReadWrite = Readable | Writable\n)"
+    },
+    {
+      "title": "Package Naming",
+      "code": "// パッケージ名は小文字の単一単語\npackage http"
+    },
+    {
+      "title": "Exported Identifiers (CamelCase)",
+      "code": "// エクスポートされる識別子には CamelCase (パッケージ外から見える)\ntype Customer struct{}\nfunc WriteFile() {}\nvar MaxLength int"
+    },
+    {
+      "title": "Unexported Identifiers (camelCase)",
+      "code": "// エクスポートされない識別子には camelCase (パッケージ内プライベート)\ntype httpClient struct{}\nfunc writeLog() {}\nvar maxRetries int"
+    },
+    {
+      "title": "Acronyms in Identifiers",
+      "code": "// 頭字語は識別子内ですべて大文字\n// e.g., HTTP, URL, ID\nvar userID string\nfunc parseHTTPResponse() {}"
+    },
+    {
+      "title": "Interface Naming (-er Suffix)",
+      "code": "// 単一メソッドのインターフェースは -er で終わる\ntype Reader interface {\n  Read(p []byte) (n int, err error)\n}"
+    },
+    {
+      "title": "Packages and Directories",
+      "code": "// Go のコードはパッケージに整理される\n// 各ディレクトリはパッケージ\n// main パッケージは実行可能ファイルの入口\npackage main"
+    },
+    {
+      "title": "Import Statements",
+      "code": "// インポートはグループ化され、ファクタリングできる\nimport (\n  \"fmt\"\n  \"io\"\n  \n// サードパーティパッケージ\n  \"golang.org/x/net/html\"\n// ローカルパッケージ\n  \"myproject/mypackage\"\n)"
+    },
+    {
+      "title": "General Go File Structure",
+      "code": "// 一般的な Go ファイルの構造:\n// 1. パッケージ宣言\n// 2. インポート\n// 3. 定数\n// 4. 変数\n// 5. 型\n// 6. 関数"
     }
   ]
 }

--- a/src/data/go-cheatsheet/concurrency.json
+++ b/src/data/go-cheatsheet/concurrency.json
@@ -2,28 +2,96 @@
   "title": "Concurrency",
   "codeExamples": [
     {
-      "title": "Goroutines",
-      "code": "// Goroutine は Go ランタイムによって管理される軽量スレッド\n\n// Goroutine を開始\ngo func() {\n  // コードは並行して実行される\n  fmt.Println(\"Running in goroutine\")\n}()\n\n// 関数を Goroutine で実行\ngo myFunction(arg1, arg2)\n\n// Main は実行を継続\nfmt.Println(\"Main function continues\")\n\n// Goroutine の終了を待つ (最も簡単な方法)\n// 本番環境では信頼できない\ntime.Sleep(time.Second)\n\n// ベストプラクティス: 同期プリミティブを使用する\nvar wg sync.WaitGroup\n\n// 1つの Goroutine のカウンターを追加\nwg.Add(1)\ngo func() {\n// Goroutine 終了時にカウンターをデクリメント\n  defer wg.Done()\n  // 処理を実行...\n}()\n\n// カウンターがゼロになるまで待機\nwg.Wait()\n\n// 複数の Goroutine を作成\nfor i := 0; i < 5; i++ {\n// クロージャの問題を避けるために新しい変数を作成\n  i := i\n  wg.Add(1)\n  go func() {\n    defer wg.Done()\n    fmt.Println(\"Goroutine\", i)\n  }()\n}\nwg.Wait()"
+      "title": "Starting Goroutines",
+      "code": "// Goroutine は Go ランタイムによって管理される軽量スレッド\n\n// Goroutine を開始\ngo func() {\n  // コードは並行して実行される\n  fmt.Println(\"Running in goroutine\")\n}()\n\n// 関数を Goroutine で実行\ngo myFunction(arg1, arg2)\n\n// Main は実行を継続\nfmt.Println(\"Main function continues\")\n\n// Goroutine の終了を待つ (最も簡単な方法)\n// 本番環境では信頼できない\ntime.Sleep(time.Second)"
     },
     {
-      "title": "Channels",
-      "code": "// チャネルは Goroutine 間の通信のための型付きパイプ\n\n// チャネルを作成\n// バッファなし\nch := make(chan int)\n// バッファあり (capacity 10)\nbuffCh := make(chan int, 10)\n\n// チャネルに送信 (矢印はチャネルを指す)\n// バッファなしチャネル、またはバッファありチャネルが満杯の場合にブロックする\nch <- 42\n\n// チャネルから受信 (矢印はチャネルから出る)\n// チャネルが空の場合にブロックする\nvalue := <-ch\n\n// チャネルを閉じる (送信側が閉じるべき)\nclose(ch)\n\n// チャネルが閉じているか確認\n// チャネルが閉じていて空の場合、ok は false\nvalue, ok := <-ch\n\n// チャネルを range で処理 (チャネルが閉じられると終了)\nfor value := range ch {\n  // 値を処理\n}\n\n// 方向性チャネル (型制限)\n// チャネルへの送信のみ可能\nfunc producer(ch chan<- int) {\n  ch <- 42\n}\n\n// チャネルからの受信のみ可能\nfunc consumer(ch <-chan int) {\n  value := <-ch\n}\n\n// チャネルパターン\n// ワーカープール\nfunc worker(id int, jobs <-chan int, results chan<- int) {\n  for j := range jobs {\n// 処理を実行\n    results <- j * 2\n  }\n}\n\njobs := make(chan int, 100)\nresults := make(chan int, 100)\n\n// 3つのワーカーを開始\nfor w := 1; w <= 3; w++ {\n  go worker(w, jobs, results)\n}\n\n// ジョブを送信し、結果を収集\nfor j := 1; j <= 9; j++ {\n  jobs <- j\n}\nclose(jobs)"
+      "title": "Waiting with sync.WaitGroup",
+      "code": "// ベストプラクティス: 同期プリミティブを使用する\nvar wg sync.WaitGroup\n\n// 1つの Goroutine のカウンターを追加\nwg.Add(1)\ngo func() {\n// Goroutine 終了時にカウンターをデクリメント\n  defer wg.Done()\n  // 処理を実行...\n}()\n\n// カウンターがゼロになるまで待機\nwg.Wait()"
     },
     {
-      "title": "Select",
-      "code": "// Select 文は複数のチャネル操作を待機できる\n\nselect {\ncase value := <-ch1:\n  // ch1 からの値を取り扱う\ncase ch2 <- value:\n  // ch2 に値を送信した\ncase <-time.After(1 * time.Second):\n  // 1秒後にタイムアウト\ncase <-done:\n  // done チャネルが閉じられた、終了\n  return\ndefault:\n  // 準備ができているチャネルがない場合に実行 (ノンブロッキング)\n}\n\n// 一般的なパターン\n\n// ノンブロッキングチャネル操作\nselect {\ncase x := <-ch:\n  // x を使用\ndefault:\n  // チャネル準備未完了\n}\n\n// タイムアウト\nselect {\ncase res := <-ch:\n  // res を使用\ncase <-time.After(time.Second):\n  // 1秒後にタイムアウトした\n}\n\n// 終了チャネル\nfunc worker(ch <-chan int, quit <-chan bool) {\n  for {\n    select {\n    case value := <-ch:\n      // 値を処理\n    case <-quit:\n      fmt.Println(\"Quitting\")\n      return\n    }\n  }\n}\n\n// 多方向 select ループ\nfor {\n  select {\n  case <-ch1:\n    // イベント1を処理\n  case <-ch2:\n    // イベント2を処理\n  case <-done:\n    return\n  }\n}"
+      "title": "Multiple Goroutines with WaitGroup",
+      "code": "// 複数の Goroutine を作成\nvar wg sync.WaitGroup\nfor i := 0; i < 5; i++ {\n// クロージャの問題を避けるために新しい変数を作成\n  i := i\n  wg.Add(1)\n  go func() {\n    defer wg.Done()\n    fmt.Println(\"Goroutine\", i)\n  }()\n}\nwg.Wait()"
     },
     {
-      "title": "Mutex and Sync",
-      "code": "// 共有データへの安全な並行アクセスのための相互排他\nimport \"sync\"\n\n// 基本的な mutex の使用法\nvar (\n  mu    sync.Mutex\n  count int\n)\n\nfunc increment() {\n// 共有データアクセス前にロック\n  mu.Lock()\n// アンロックが確実に行われるようにする\n  defer mu.Unlock()\n  count++\n}\n\n// 読み書き mutex (複数のリーダーまたは1つのライター)\nvar rwmu sync.RWMutex\n\nfunc readData() {\n// 複数の Goroutine が読み取りロックを保持できる\n  rwmu.RLock()\n  defer rwmu.RUnlock()\n  // 共有データを読み取る...\n}\n\nfunc writeData() {\n// 書き込みのための排他ロック\n  rwmu.Lock()\n  defer rwmu.Unlock()\n  // 共有データを変更する...\n}\n\n// Once - 厳密に一度だけ実行\nvar once sync.Once\n\nfunc initialize() {\n  once.Do(func() {\n    // 初期化コード、厳密に一度だけ実行される\n  })\n}\n\n// WaitGroup - Goroutine のコレクションを待機\nvar wg sync.WaitGroup\n\n// カウンターを3に設定\nwg.Add(3)\ngo func() {\n// カウンターをデクリメント\n  defer wg.Done()\n  // 処理 1\n}()\n// ... さらに Goroutine を起動\n// カウンターがゼロになるまでブロック\nwg.Wait()\n\n// Cond - イベント待機のための条件変数\ncond := sync.NewCond(&sync.Mutex{})\n\n// ブロードキャスト\ncond.L.Lock()\n// 状態を変更\n// すべての待機者を起こす\ncond.Broadcast()\ncond.L.Unlock()\n\n// 待機中\ncond.L.Lock()\nfor !condition() {\n// アンロックし、待機し、再度ロックする\n  cond.Wait()\n}\n// 条件を使用\ncond.L.Unlock()"
+      "title": "Channel Basics (Create, Send, Receive, Close)",
+      "code": "// チャネルは Goroutine 間の通信のための型付きパイプ\n\n// チャネルを作成\n// バッファなし\nch := make(chan int)\n// バッファあり (capacity 10)\nbuffCh := make(chan int, 10)\n\n// チャネルに送信 (矢印はチャネルを指す)\n// バッファなしチャネル、またはバッファありチャネルが満杯の場合にブロックする\nch <- 42\n\n// チャネルから受信 (矢印はチャネルから出る)\n// チャネルが空の場合にブロックする\nvalue := <-ch\n\n// チャネルを閉じる (送信側が閉じるべき)\nclose(ch)\n\n// チャネルが閉じているか確認\n// チャネルが閉じていて空の場合、ok は false\nvalue, ok := <-ch"
     },
     {
-      "title": "Atomic Operations",
-      "code": "// 低レベル同期のためのアトミック操作\nimport \"sync/atomic\"\n\n// Go 1.19+\nvar counter atomic.Int64\n\n// 値を追加して取得\ncounter.Add(10)\nvalue := counter.Load()\n\n// 比較して交換\n// 値が 10 なら 20 に設定\nswapped := counter.CompareAndSwap(10, 20)\n\n// 値を格納\ncounter.Store(100)\n\n// In Go <1.19\nvar counter int64\n\n// 追加して取得\natomic.AddInt64(&counter, 10)\nvalue := atomic.LoadInt64(&counter)\n\n// 比較して交換\nswapped := atomic.CompareAndSwapInt64(&counter, 10, 20)\n\n// 値を格納\natomic.StoreInt64(&counter, 100)\n\n// アトミックポインタ操作\n// Go 1.19+\nvar ptr atomic.Pointer[T]\nptr.Store(&myStruct)\nvalue := ptr.Load()\nswapped := ptr.CompareAndSwap(oldPtr, newPtr)"
+      "title": "Ranging Over Channels",
+      "code": "// チャネルを range で処理 (チャネルが閉じられると終了)\nch := make(chan int, 2)\nch <- 1\nch <- 2\nclose(ch)\nfor value := range ch {\n  // 値を処理 (1, 2)\n  fmt.Println(value)\n}"
     },
     {
-      "title": "Context",
-      "code": "// Context はデッドライン、キャンセルシグナル、リクエストスコープの値を運ぶ\nimport \"context\"\n\n// Context の作成\n// Background context (すべての context のルート)\nctx := context.Background()\n\n// WithCancel - キャンセル可能な context\nctx, cancel := context.WithCancel(context.Background())\n// 完了時にキャンセル\ndefer cancel()\n\n// 時間制限付き context\nctx, cancel := context.WithTimeout(context.Background(), time.Second)\ndefer cancel()\n\nctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))\ndefer cancel()\n\n// Context 値 (リクエストスコープデータ用)\nctx = context.WithValue(ctx, \"key\", \"value\")\nvalue := ctx.Value(\"key\").(string)\n\n// 関数での context の使用\nfunc doWork(ctx context.Context) error {\n  select {\n  case <-time.After(100 * time.Millisecond):\n    return nil\n  case <-ctx.Done():\n// context.Canceled or context.DeadlineExceeded\n    return ctx.Err()\n  }\n}\n\n// キャンセル\nctx, cancel := context.WithCancel(context.Background())\ngo func() {\n  time.Sleep(time.Second)\n// キャンセルを通知\n  cancel()\n}()\ndoWork(ctx)"
+      "title": "Directional Channels",
+      "code": "// 方向性チャネル (型制限)\n// チャネルへの送信のみ可能\nfunc producer(ch chan<- int) {\n  ch <- 42\n  // <-ch // コンパイルエラー\n}\n\n// チャネルからの受信のみ可能\nfunc consumer(ch <-chan int) {\n  value := <-ch\n  // ch <- 42 // コンパイルエラー\n  fmt.Println(value)\n}"
+    },
+    {
+      "title": "Worker Pool Pattern",
+      "code": "// チャネルパターン: ワーカープール\nfunc worker(id int, jobs <-chan int, results chan<- int) {\n  for j := range jobs {\n    fmt.Printf(\"Worker %d processing job %d\\n\", id, j)\n    time.Sleep(time.Millisecond * 500) // 処理をシミュレート\n    results <- j * 2\n  }\n}\n\njobs := make(chan int, 100)\nresults := make(chan int, 100)\n\n// 3つのワーカーを開始\nnumWorkers := 3\nfor w := 1; w <= numWorkers; w++ {\n  go worker(w, jobs, results)\n}\n\n// ジョブを送信\nnumJobs := 9\nfor j := 1; j <= numJobs; j++ {\n  jobs <- j\n}\nclose(jobs)\n\n// 結果を収集\nfor a := 1; a <= numJobs; a++ {\n  <-results\n}"
+    },
+    {
+      "title": "Basic Select",
+      "code": "// Select 文は複数のチャネル操作を待機できる\nch1 := make(chan string)\nch2 := make(chan string)\n\ngo func() { time.Sleep(1 * time.Second); ch1 <- \"one\" }()\ngo func() { time.Sleep(2 * time.Second); ch2 <- \"two\" }()\n\nfor i := 0; i < 2; i++ {\n  select {\n  case msg1 := <-ch1:\n    fmt.Println(\"received\", msg1)\n  case msg2 := <-ch2:\n    fmt.Println(\"received\", msg2)\n  }\n}"
+    },
+    {
+      "title": "Select with Timeout",
+      "code": "// タイムアウト\nch := make(chan string, 1)\ngo func() {\n  time.Sleep(2 * time.Second)\n  ch <- \"result\"\n}()\n\nselect {\ncase res := <-ch:\n  fmt.Println(res)\ncase <-time.After(1 * time.Second):\n  fmt.Println(\"timeout 1\")\n}"
+    },
+    {
+      "title": "Select with Quit Channel",
+      "code": "// 終了チャネル\nfunc worker(ch <-chan int, quit <-chan bool) {\n  for {\n    select {\n    case value := <-ch:\n      fmt.Println(\"Processing\", value)\n    case <-quit:\n      fmt.Println(\"Quitting\")\n      return\n    }\n  }\n}\n\nch := make(chan int)\nquit := make(chan bool)\n\ngo worker(ch, quit)\n\nch <- 1\nch <- 2\nquit <- true"
+    },
+    {
+      "title": "Non-Blocking Select (Default Case)",
+      "code": "// ノンブロッキングチャネル操作\nch := make(chan string)\n\nselect {\ncase msg := <-ch:\n  fmt.Println(\"received message\", msg)\ndefault:\n  fmt.Println(\"no message received\")\n}"
+    },
+    {
+      "title": "Mutex (sync.Mutex)",
+      "code": "// 共有データへの安全な並行アクセスのための相互排他\nimport \"sync\"\n\nvar (\n  mu    sync.Mutex\n  count int\n)\n\nfunc increment() {\n// 共有データアクセス前にロック\n  mu.Lock()\n// アンロックが確実に行われるようにする\n  defer mu.Unlock()\n  count++\n}\n\n// 使用例\ngo increment()\ngo increment()\n// 最終的な count は 2 になる (競合状態なし)"
+    },
+    {
+      "title": "RWMutex (sync.RWMutex)",
+      "code": "// 読み書き mutex (複数のリーダーまたは1つのライター)\nvar (\n  rwmu   sync.RWMutex\n  balance int\n)\n\nfunc readBalance() int {\n// 複数の Goroutine が読み取りロックを保持できる\n  rwmu.RLock()\n  defer rwmu.RUnlock()\n  return balance\n}\n\nfunc writeBalance(amount int) {\n// 書き込みのための排他ロック\n  rwmu.Lock()\n  defer rwmu.Unlock()\n  balance += amount\n}"
+    },
+    {
+      "title": "Once (sync.Once)",
+      "code": "// Once - 厳密に一度だけ実行\nvar once sync.Once\n\nfunc initialize() {\n  fmt.Println(\"Initializing...\")\n  // 初期化コード\n}\n\nfunc getInstance() {\n  once.Do(initialize) // initialize は一度だけ呼び出される\n  fmt.Println(\"Instance ready\")\n}\n\ngo getInstance()\ngo getInstance()"
+    },
+    {
+      "title": "WaitGroup (sync.WaitGroup)",
+      "code": "// WaitGroup - Goroutine のコレクションを待機\nvar wg sync.WaitGroup\n\n// カウンターを3に設定\nwg.Add(3)\ngo func() {\n  defer wg.Done() // カウンターをデクリメント\n  fmt.Println(\"Task 1 done\")\n}()\ngo func() {\n  defer wg.Done()\n  fmt.Println(\"Task 2 done\")\n}()\ngo func() {\n  defer wg.Done()\n  fmt.Println(\"Task 3 done\")\n}()\n\n// カウンターがゼロになるまでブロック\nwg.Wait()\nfmt.Println(\"All tasks completed\")"
+    },
+    {
+      "title": "Cond (sync.Cond)",
+      "code": "// Cond - イベント待機のための条件変数\nvar sharedRsc = make(map[string]string)\nvar mu sync.Mutex\ncond := sync.NewCond(&mu)\n\ngo func() { // producer\n  time.Sleep(1 * time.Second)\n  cond.L.Lock()\n  sharedRsc[\"data\"] = \"some data\"\n  fmt.Println(\"Producer produced data\")\n  cond.Signal() // 待機中の Goroutine を1つ起こす\n  // cond.Broadcast() // すべての待機者を起こす\n  cond.L.Unlock()\n}()\n\n// consumer\ncond.L.Lock()\nfor sharedRsc[\"data\"] == \"\" { // 条件をチェック\n  fmt.Println(\"Consumer waiting...\")\n  cond.Wait() // アンロックし、待機し、再度ロックする\n}\nfmt.Println(\"Consumer received:\", sharedRsc[\"data\"])\ncond.L.Unlock()"
+    },
+    {
+      "title": "Atomic Integers (Go 1.19+)",
+      "code": "// 低レベル同期のためのアトミック操作 (Go 1.19+)\nimport \"sync/atomic\"\n\nvar counter atomic.Int64\n\n// 値を追加して取得\ncounter.Add(10)\nvalue := counter.Load()\nfmt.Println(\"Counter:\", value) // 10\n\n// 比較して交換\n// 値が 10 なら 20 に設定\nswapped := counter.CompareAndSwap(10, 20)\nfmt.Println(\"Swapped:\", swapped) // true\nfmt.Println(\"Counter:\", counter.Load()) // 20\n\n// 値を格納\ncounter.Store(100)\nfmt.Println(\"Counter:\", counter.Load()) // 100"
+    },
+    {
+      "title": "Atomic Integers (Go <1.19)",
+      "code": "// Go <1.19 のアトミック操作\nimport \"sync/atomic\"\n\nvar counter int64\n\n// 追加して取得\natomic.AddInt64(&counter, 10)\nvalue := atomic.LoadInt64(&counter)\nfmt.Println(\"Counter:\", value) // 10\n\n// 比較して交換\nswapped := atomic.CompareAndSwapInt64(&counter, 10, 20)\nfmt.Println(\"Swapped:\", swapped) // true\nfmt.Println(\"Counter:\", atomic.LoadInt64(&counter)) // 20\n\n// 値を格納\natomic.StoreInt64(&counter, 100)\nfmt.Println(\"Counter:\", atomic.LoadInt64(&counter)) // 100"
+    },
+    {
+      "title": "Atomic Pointers (Go 1.19+)",
+      "code": "// アトミックポインタ操作 (Go 1.19+)\nimport \"sync/atomic\"\n\ntype Config struct{ Version string }\n\nvar cfg atomic.Pointer[Config]\n\noldCfg := &Config{Version: \"v1\"}\nnewCfg := &Config{Version: \"v2\"}\n\ncfg.Store(oldCfg)\n\nloadedCfg := cfg.Load()\nfmt.Println(\"Loaded Cfg:\", loadedCfg.Version) // v1\n\nswapped := cfg.CompareAndSwap(oldCfg, newCfg)\nfmt.Println(\"Swapped Ptr:\", swapped) // true\nfmt.Println(\"Loaded Cfg:\", cfg.Load().Version) // v2"
+    },
+    {
+      "title": "Creating Contexts",
+      "code": "// Context はデッドライン、キャンセルシグナル、リクエストスコープの値を運ぶ\nimport (\n  \"context\"\n  \"time\"\n)\n\n// Context の作成\n// Background context (すべての context のルート)\nctxBg := context.Background()\n\n// WithCancel - キャンセル可能な context\nctxCancel, cancelFunc := context.WithCancel(ctxBg)\ndefer cancelFunc() // 完了時にキャンセル\n\n// 時間制限付き context\nctxTimeout, cancelTimeout := context.WithTimeout(ctxBg, time.Second)\ndefer cancelTimeout()\n\nctxDeadline, cancelDeadline := context.WithDeadline(ctxBg, time.Now().Add(time.Minute))\ndefer cancelDeadline()"
+    },
+    {
+      "title": "Context with Values",
+      "code": "// Context 値 (リクエストスコープデータ用)\ntype ctxKey string\nconst requestIDKey ctxKey = \"requestID\"\n\nctx := context.WithValue(context.Background(), requestIDKey, \"12345\")\n\n// 値を取得\nvalue, ok := ctx.Value(requestIDKey).(string)\nif ok {\n  fmt.Println(\"Request ID:\", value) // 12345\n}"
+    },
+    {
+      "title": "Using Context in Functions (Checking Done)",
+      "code": "// 関数での context の使用\nfunc doWork(ctx context.Context) error {\n  select {\n  case <-time.After(2 * time.Second): // 作業をシミュレート\n    fmt.Println(\"Work done\")\n    return nil\n  case <-ctx.Done(): // context がキャンセルされたか確認\n    fmt.Println(\"Work cancelled\")\n    // context.Canceled or context.DeadlineExceeded\n    return ctx.Err()\n  }\n}"
+    },
+    {
+      "title": "Context Cancellation",
+      "code": "// キャンセル\nctx, cancel := context.WithCancel(context.Background())\n\nvar wg sync.WaitGroup\nwg.Add(1)\ngo func(innerCtx context.Context) {\n  defer wg.Done()\n  err := doWork(innerCtx)\n  if err != nil {\n    fmt.Println(\"Goroutine error:\", err)\n  }\n}(ctx)\n\n// 少し待ってからキャンセル\ntime.Sleep(500 * time.Millisecond)\nfmt.Println(\"Cancelling context\")\ncancel() // キャンセルを通知\n\nwg.Wait()"
     }
   ]
 }

--- a/src/data/go-cheatsheet/context.json
+++ b/src/data/go-cheatsheet/context.json
@@ -2,28 +2,88 @@
   "title": "Context",
   "codeExamples": [
     {
-      "title": "Context Basics",
-      "code": "// Context はデッドライン、キャンセルシグナル、リクエストスコープの値を\n// API 境界を越えて、プロセス間で運ぶ\nimport \"context\"\n\n// Context の作成\n// Background - ルート context、キャンセルされない、値なし、デッドラインなし\nctx := context.Background()\n\n// TODO - Background に似ているが、特定の context を\n// 使用すべきだがまだ利用できないことを示す\nctx := context.TODO()\n\n// 最初のパラメータとして context を渡すのは慣例\nfunc DoSomething(ctx context.Context, arg Arg) error {\n  // ... context を使用 ...\n}\n\n// 常に context を渡す\nctx := context.Background()\nDoSomething(ctx, arg)\n\n// context を取る関数を連鎖させる\nfunc DoSomethingMore(ctx context.Context, arg Arg) (Result, error) {\n  // context を取る別の関数を呼び出す\n  err := DoSomething(ctx, arg)\n  if err != nil {\n    return Result{}, err\n  }\n  // context でさらに処理を行う\n  return Result{}, nil\n}"
+      "title": "Context Overview",
+      "code": "// Context はデッドライン、キャンセルシグナル、リクエストスコープの値を\n// API 境界を越えて、プロセス間で運ぶ\nimport \"context\""
     },
     {
-      "title": "Cancellation",
-      "code": "// context によるキャンセル\n\n// キャンセル可能な context を作成\nctx, cancel := context.WithCancel(context.Background())\n\n// リソースを解放するために常に cancel を呼び出す、通常は defer を使用\ndefer cancel()\n\n// キャンセル可能な goroutine を開始\ngo func() {\n  for {\n    select {\n    case <-ctx.Done():\n      // Context がキャンセルされた、処理を停止\n      fmt.Println(\"Stopped due to cancellation\")\n      return\n    default:\n      // 何らかの処理を行う\n      time.Sleep(100 * time.Millisecond)\n    }\n  }\n}()\n\n// 後でキャンセルをトリガー\ncancel()\n\n// context がキャンセルされたか確認\nif ctx.Err() == context.Canceled {\n  fmt.Println(\"Context was canceled\")\n}\n\n// ワーカーでの典型的な使用法\nfunc worker(ctx context.Context, tasks <-chan Task) {\n  for {\n    select {\n    case task, ok := <-tasks:\n      if !ok {\n// チャネルが閉じられた\n        return\n      }\n      process(ctx, task)\n    case <-ctx.Done():\n      fmt.Println(\"Worker stopping:\", ctx.Err())\n      return\n    }\n  }\n}"
+      "title": "Creating Basic Contexts",
+      "code": "// Context の作成\n// Background - ルート context、キャンセルされない、値なし、デッドラインなし\nctxBg := context.Background()\n\n// TODO - Background に似ているが、特定の context を\n// 使用すべきだがまだ利用できないことを示す\nctxTodo := context.TODO()"
     },
     {
-      "title": "Timeouts and Deadlines",
-      "code": "// context によるタイムアウトとデッドライン\n\n// タイムアウト付き Context - 指定時間後に自動的にキャンセルされる\nctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)\n// タイムアウト前に完了した場合でも、リソースを早期に解放するために cancel を呼び出す\ndefer cancel()\n\n// デッドライン付き Context - 特定の時間にキャンセルされる\ndeadline := time.Now().Add(30 * time.Second)\nctx, cancel := context.WithDeadline(context.Background(), deadline)\ndefer cancel()\n\n// タイムアウトまたはデッドライン超過の確認\nif ctx.Err() == context.DeadlineExceeded {\n  fmt.Println(\"Operation timed out or deadline exceeded\")\n}\n\n// HTTP クライアントでの使用\nctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)\ndefer cancel()\n\n//example.com\", nil)\nreq, err := http.NewRequestWithContext(ctx, \"GET\", \"https:\nif err != nil {\n  return err\n}\n\nresp, err := http.DefaultClient.Do(req)\nif err != nil {\n  // リクエストに時間がかかりすぎた場合、context.DeadlineExceeded になる可能性がある\n  return err\n}\ndefer resp.Body.Close()\n\n// データベース操作での使用\nctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)\ndefer cancel()\n\nrows, err := db.QueryContext(ctx, \"SELECT * FROM users\")\nif err != nil {\n  return err\n}\ndefer rows.Close()"
+      "title": "Passing Context (Convention)",
+      "code": "// 最初のパラメータとして context を渡すのは慣例\nfunc DoSomething(ctx context.Context, arg Arg) error {\n  // ... context を使用 ...\n  return nil\n}\n\n// 常に context を渡す\nctx := context.Background()\nDoSomething(ctx, arg)"
     },
     {
-      "title": "Context Values",
-      "code": "// Context 値 - リクエストスコープのキーバリューペア\n\n// context に値を追加 (新しい context を作成)\nctx = context.WithValue(ctx, \"userID\", \"12345\")\nctx = context.WithValue(ctx, \"authToken\", \"token-123\")\n\n// 値の取得\nuserID, ok := ctx.Value(\"userID\").(string)\nif !ok {\n  fmt.Println(\"UserID not found or not a string\")\n}\n\n// ベストプラクティス: キーとしてカスタム型を使用する\n// パッケージ間でのキー衝突を避けるため\ntype contextKey string\n\nconst (\n  userIDKey   contextKey = \"userID\"\n  authTokenKey contextKey = \"authToken\"\n)\n\nctx = context.WithValue(ctx, userIDKey, \"12345\")\nuserID, ok := ctx.Value(userIDKey).(string)\n\n// より良い名前空間分離のためにキーとして構造体を使用する\ntype UserContextKey struct{}\ntype RequestContextKey struct{}\n\nctx = context.WithValue(ctx, UserContextKey{}, user)\nctx = context.WithValue(ctx, RequestContextKey{}, request)\n\nuser, ok := ctx.Value(UserContextKey{}).(User)\n\n// 警告: オプションパラメータを渡すために context 値を使用しない\n// 主に API 境界を越えるリクエストスコープデータに使用する"
+      "title": "Chaining Context-Aware Functions",
+      "code": "// context を取る関数を連鎖させる\nfunc DoSomethingMore(ctx context.Context, arg Arg) (Result, error) {\n  // context を取る別の関数を呼び出す\n  err := DoSomething(ctx, arg)\n  if err != nil {\n    return Result{}, err\n  }\n  // context でさらに処理を行う\n  return Result{}, nil\n}"
     },
     {
-      "title": "Context Patterns",
-      "code": "// 一般的な context パターンとベストプラクティス\n\n// コールスタックを通じて context を伝播させる\nfunc HandleRequest(w http.ResponseWriter, r *http.Request) {\n  // リクエスト context を抽出\n  ctx := r.Context()\n  \n  // タイムアウトを追加\n  ctx, cancel := context.WithTimeout(ctx, 2*time.Second)\n  defer cancel()\n  \n  // リクエストを処理\n  result, err := processRequest(ctx, r.URL.Query())\n  if err != nil {\n    http.Error(w, err.Error(), http.StatusInternalServerError)\n    return\n  }\n  \n  w.Write(result)\n}\n\nfunc processRequest(ctx context.Context, params url.Values) ([]byte, error) {\n  // context がキャンセルされたか確認\n  select {\n  case <-ctx.Done():\n    return nil, ctx.Err()\n  default:\n    // 処理を続行\n  }\n  \n  // データベースからデータを取得\n  data, err := getFromDatabase(ctx, params.Get(\"id\"))\n  if err != nil {\n    return nil, err\n  }\n  \n  // データを処理\n  return processData(ctx, data)\n}\n\n// ミドルウェアでの context\nfunc Middleware(next http.Handler) http.Handler {\n  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n    // リクエスト context を強化\n    ctx := r.Context()\n    ctx = context.WithValue(ctx, \"startTime\", time.Now())\n    \n    // 強化された context で次のハンドラを呼び出す\n    next.ServeHTTP(w, r.WithContext(ctx))\n  })\n}"
+      "title": "Creating Cancellable Context",
+      "code": "// context によるキャンセル\n\n// キャンセル可能な context を作成\nctx, cancel := context.WithCancel(context.Background())\n\n// リソースを解放するために常に cancel を呼び出す、通常は defer を使用\ndefer cancel()"
     },
     {
-      "title": "Testing with Context",
-      "code": "// context を使用したテスト\nfunc TestWithContext(t *testing.T) {\n  // タイムアウト付きの context を作成\n  ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)\n  defer cancel()\n  \n  // context を尊重すべき関数を呼び出す\n  result, err := functionThatUsesContext(ctx)\n  \n  // 結果を確認\n  if err != context.DeadlineExceeded {\n    t.Errorf(\"Expected DeadlineExceeded, got %v\", err)\n  }\n  \n  // キャンセルのテスト\n  ctx, cancel = context.WithCancel(context.Background())\n  \n  // 短時間後にキャンセルする goroutine を開始\n  go func() {\n    time.Sleep(10 * time.Millisecond)\n    cancel()\n  }()\n  \n  err = functionThatShouldObserveCancel(ctx)\n  if err != context.Canceled {\n    t.Errorf(\"Expected Canceled, got %v\", err)\n  }\n}\n\n// テスト用の context モックを作成\ntype contextMock struct {\n  context.Context\n  doneChannel chan struct{}\n}\n\nfunc (c *contextMock) Done() <-chan struct{} {\n  return c.doneChannel\n}\n\nfunc (c *contextMock) Err() error {\n  select {\n  case <-c.doneChannel:\n    return context.Canceled\n  default:\n    return nil\n  }\n}"
+      "title": "Responding to Cancellation",
+      "code": "// キャンセル可能な goroutine を開始\ngo func(innerCtx context.Context) {\n  for {\n    select {\n    case <-innerCtx.Done():\n      // Context がキャンセルされた、処理を停止\n      fmt.Println(\"Stopped due to cancellation\")\n      return\n    default:\n      // 何らかの処理を行う\n      fmt.Println(\"Working...\")\n      time.Sleep(100 * time.Millisecond)\n    }\n  }\n}(ctx)\n\n// 後でキャンセルをトリガー\ntime.Sleep(500 * time.Millisecond)\ncancel()\n\n// context がキャンセルされたか確認\nif ctx.Err() == context.Canceled {\n  fmt.Println(\"Context was canceled\")\n}"
+    },
+    {
+      "title": "Cancellation in Worker Pattern",
+      "code": "// ワーカーでの典型的な使用法\nfunc worker(ctx context.Context, tasks <-chan Task) {\n  for {\n    select {\n    case task, ok := <-tasks:\n      if !ok {\n// チャネルが閉じられた\n        return\n      }\n      process(ctx, task)\n    case <-ctx.Done():\n      fmt.Println(\"Worker stopping:\", ctx.Err())\n      return\n    }\n  }\n}"
+    },
+    {
+      "title": "Context with Timeout",
+      "code": "// タイムアウト付き Context - 指定時間後に自動的にキャンセルされる\nctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), 2*time.Second)\n// タイムアウト前に完了した場合でも、リソースを早期に解放するために cancel を呼び出す\ndefer cancelTimeout()"
+    },
+    {
+      "title": "Context with Deadline",
+      "code": "// デッドライン付き Context - 特定の時間にキャンセルされる\ndeadline := time.Now().Add(30 * time.Second)\nctxDeadline, cancelDeadline := context.WithDeadline(context.Background(), deadline)\ndefer cancelDeadline()"
+    },
+    {
+      "title": "Checking for Timeout/Deadline Exceeded",
+      "code": "// タイムアウトまたはデッドライン超過の確認\nif ctxTimeout.Err() == context.DeadlineExceeded {\n  fmt.Println(\"Operation timed out or deadline exceeded\")\n}"
+    },
+    {
+      "title": "Timeout/Deadline in HTTP Client",
+      "code": "// HTTP クライアントでの使用\nctxHttp, cancelHttp := context.WithTimeout(context.Background(), 2*time.Second)\ndefer cancelHttp()\n\n//example.com\", nil)\nreq, err := http.NewRequestWithContext(ctxHttp, \"GET\", \"https:\nif err != nil {\n  // エラー処理\n}\n\nresp, err := http.DefaultClient.Do(req)\nif err != nil {\n  // リクエストに時間がかかりすぎた場合、context.DeadlineExceeded になる可能性がある\n  if errors.Is(err, context.DeadlineExceeded) {\n    fmt.Println(\"HTTP request timed out\")\n  }\n  // その他のエラー処理\n}\nif resp != nil {\n  defer resp.Body.Close()\n}"
+    },
+    {
+      "title": "Timeout/Deadline in Database Operations",
+      "code": "// データベース操作での使用\nctxDb, cancelDb := context.WithTimeout(context.Background(), 1*time.Second)\ndefer cancelDb()\n\n// db は *sql.DB\nrows, err := db.QueryContext(ctxDb, \"SELECT * FROM users WHERE id = ?\", 1)\nif err != nil {\n  if errors.Is(err, context.DeadlineExceeded) {\n    fmt.Println(\"Database query timed out\")\n  }\n  // その他のエラー処理\n}\nif rows != nil {\n  defer rows.Close()\n}"
+    },
+    {
+      "title": "Adding Values to Context",
+      "code": "// Context 値 - リクエストスコープのキーバリューペア\n\n// context に値を追加 (新しい context を作成)\nctx := context.Background()\nctx = context.WithValue(ctx, \"userID\", \"12345\")\nctx = context.WithValue(ctx, \"authToken\", \"token-123\")"
+    },
+    {
+      "title": "Retrieving Values from Context",
+      "code": "// 値の取得\nuserID, ok := ctx.Value(\"userID\").(string)\nif !ok {\n  fmt.Println(\"UserID not found or not a string\")\n} else {\n  fmt.Println(\"UserID:\", userID)\n}"
+    },
+    {
+      "title": "Context Value Keys (Best Practice)",
+      "code": "// ベストプラクティス: キーとしてカスタム型を使用する\n// パッケージ間でのキー衝突を避けるため\ntype contextKey string\n\nconst (\n  userIDKey   contextKey = \"userID\"\n  authTokenKey contextKey = \"authToken\"\n)\n\nctx := context.WithValue(context.Background(), userIDKey, \"12345\")\nuserID, ok := ctx.Value(userIDKey).(string)\n\n// より良い名前空間分離のためにキーとして構造体を使用する\ntype UserContextKey struct{}\ntype RequestContextKey struct{}\n\nctx = context.WithValue(ctx, UserContextKey{}, user)\nctx = context.WithValue(ctx, RequestContextKey{}, request)\n\nuserVal, ok := ctx.Value(UserContextKey{}).(User)"
+    },
+    {
+      "title": "Context Value Warning",
+      "code": "// 警告: オプションパラメータを渡すために context 値を使用しない\n// 主に API 境界を越えるリクエストスコープデータに使用する"
+    },
+    {
+      "title": "Propagating Context Through Call Stack",
+      "code": "// コールスタックを通じて context を伝播させる\nfunc HandleRequest(w http.ResponseWriter, r *http.Request) {\n  // リクエスト context を抽出\n  ctx := r.Context()\n  \n  // タイムアウトを追加\n  ctx, cancel := context.WithTimeout(ctx, 2*time.Second)\n  defer cancel()\n  \n  // リクエストを処理\n  result, err := processRequest(ctx, r.URL.Query())\n  if err != nil {\n    http.Error(w, err.Error(), http.StatusInternalServerError)\n    return\n  }\n  \n  w.Write(result)\n}\n\nfunc processRequest(ctx context.Context, params url.Values) ([]byte, error) {\n  // context がキャンセルされたか確認\n  select {\n  case <-ctx.Done():\n    return nil, ctx.Err()\n  default:\n    // 処理を続行\n  }\n  \n  // データベースからデータを取得\n  data, err := getFromDatabase(ctx, params.Get(\"id\"))\n  if err != nil {\n    return nil, err\n  }\n  \n  // データを処理\n  return processData(ctx, data)\n}"
+    },
+    {
+      "title": "Context in Middleware",
+      "code": "// ミドルウェアでの context\nfunc Middleware(next http.Handler) http.Handler {\n  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n    // リクエスト context を強化\n    ctx := r.Context()\n    ctx = context.WithValue(ctx, \"startTime\", time.Now())\n    \n    // 強化された context で次のハンドラを呼び出す\n    next.ServeHTTP(w, r.WithContext(ctx))\n  })\n}"
+    },
+    {
+      "title": "Testing with Timeout Context",
+      "code": "// context を使用したテスト\nfunc TestWithTimeoutContext(t *testing.T) {\n  // タイムアウト付きの context を作成\n  ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)\n  defer cancel()\n  \n  // context を尊重すべき関数を呼び出す\n  result, err := functionThatUsesContext(ctx)\n  \n  // 結果を確認\n  if !errors.Is(err, context.DeadlineExceeded) {\n    t.Errorf(\"Expected DeadlineExceeded, got %v\", err)\n  }\n}"
+    },
+    {
+      "title": "Testing with Cancellation Context",
+      "code": "// キャンセルのテスト\nfunc TestWithCancelContext(t *testing.T) {\n  ctx, cancel := context.WithCancel(context.Background())\n  \n  // 短時間後にキャンセルする goroutine を開始\n  go func() {\n    time.Sleep(10 * time.Millisecond)\n    cancel()\n  }()\n  \n  err := functionThatShouldObserveCancel(ctx)\n  if !errors.Is(err, context.Canceled) {\n    t.Errorf(\"Expected Canceled, got %v\", err)\n  }\n}"
+    },
+    {
+      "title": "Mocking Context for Testing",
+      "code": "// テスト用の context モックを作成 (例)\ntype contextMock struct {\n  context.Context\n  doneChannel chan struct{}\n}\n\nfunc newContextMock() (*contextMock, func()) {\n  done := make(chan struct{})\n  mock := &contextMock{\n    Context:     context.Background(),\n    doneChannel: done,\n  }\n  cancel := func() { close(done) }\n  return mock, cancel\n}\n\nfunc (c *contextMock) Done() <-chan struct{} {\n  return c.doneChannel\n}\n\nfunc (c *contextMock) Err() error {\n  select {\n  case <-c.doneChannel:\n    return context.Canceled\n  default:\n    return nil\n  }\n}\n\n// テストでの使用\nfunc TestWithMockContext(t *testing.T) {\n  mockCtx, cancelMock := newContextMock()\n  defer cancelMock()\n\n  go func() {\n    time.Sleep(50 * time.Millisecond)\n    cancelMock()\n  }()\n\n  err := functionThatUsesContext(mockCtx)\n  if !errors.Is(err, context.Canceled) {\n    t.Errorf(\"Expected Canceled with mock, got %v\", err)\n  }\n}"
     }
   ]
 }

--- a/src/data/go-cheatsheet/data-structures.json
+++ b/src/data/go-cheatsheet/data-structures.json
@@ -2,28 +2,144 @@
   "title": "Data structures",
   "codeExamples": [
     {
-      "title": "Arrays",
-      "code": "// 配列宣言 (固定サイズ)\n// [0 0 0 0 0]\nvar a [5]int\n\n// 配列の初期化\n// [1 2 3]\nb := [3]int{1, 2, 3}\n\n// 暗黙的なサイズの配列\n// [4]int - コンパイラが要素数を数える\nc := [...]int{4, 5, 6, 7}\n\n// 要素へのアクセス\n// 0\nfirst := a[0]\n// 最初の要素を 10 に設定\na[0] = 10\n\n// 多次元配列\nmatrix := [2][3]int{\n  {1, 2, 3},\n  {4, 5, 6},\n}\n// 6\nvalue := matrix[1][2]\n\n// 配列は値 (コピー)\noriginal := [3]int{1, 2, 3}\n// 完全なコピーを作成\ncopy := original\n// 元の配列には影響しない\ncopy[0] = 99\n\n// 配列のサイズは型の一部 - これらは異なる型\nvar a1 [5]int\nvar a2 [10]int\n// a1 = a2  // コンパイルエラー - 異なる型"
+      "title": "Array Declaration",
+      "code": "// 配列宣言 (固定サイズ)\n// [0 0 0 0 0]\nvar a [5]int"
     },
     {
-      "title": "Slices",
-      "code": "// スライス宣言 (配列の動的サイズのビュー)\n// nil スライス (長さと容量は 0)\nvar s []int\n\n// スライスを作成\n// len=5, cap=5, ゼロ値で初期化\ns = make([]int, 5)\n// len=3, cap=10, ゼロ値で初期化\ns = make([]int, 3, 10)\n\n// スライスリテラル\n// len=3, cap=3\ns = []int{1, 2, 3}\n\n// 既存の配列またはスライスからのスライス\na := [5]int{1, 2, 3, 4, 5}\n// s == []int{2, 3, 4}, len=3, cap=4\ns := a[1:4]\n\n// スライスのインデックス\nfull := []int{1, 2, 3, 4, 5}\n// [2 3 4]   - インデックス 1 から 3 まで (4 は含まない)\ns1 := full[1:4]\n// [1 2 3]   - 開始からインデックス 2 まで\ns2 := full[:3]\n// [3 4 5]   - インデックス 2 から最後まで\ns3 := full[2:]\n// [1 2 3 4 5] - スライス全体\ns4 := full[:]\n\n// スライスに追加 (必要に応じて新しい基底配列を作成することがある)\n// 要素 4 と 5 を追加\ns = append(s, 4, 5)\nt := []int{6, 7, 8}\n// 別のスライスを追加\ns = append(s, t...)\n\n// スライスの長さと容量\n// 要素数\nlen := len(s)\n// 基底配列の容量\ncap := cap(s)\n\n// 一般的なスライス操作\n// コピー\ndst := make([]int, len(src))\n// src から dst へコピー、コピーされた要素数を返す\ncopy(dst, src)\n\n// インデックス i の要素を削除\ns = append(s[:i], s[i+1:]...)\n\n// インデックス i に要素を挿入\ns = append(s[:i], append([]int{x}, s[i:]...)...)\n// より効率的な挿入\n// 末尾にゼロ値を追加\ns = append(s, 0)\n// 要素を右にシフト\ncopy(s[i+1:], s[i:])\n// 新しい要素を配置\ns[i] = x"
+      "title": "Array Initialization",
+      "code": "// 配列の初期化\n// [1 2 3]\nb := [3]int{1, 2, 3}"
     },
     {
-      "title": "Maps",
-      "code": "// マップ宣言 (キーバリューストア、順序なし)\n// nil マップ (読み取りは可能だが書き込みは不可)\nvar m map[string]int\n\n// マップを作成\nm = make(map[string]int)\n\n// マップリテラル\nm = map[string]int{\n  \"one\": 1,\n  \"two\": 2,\n}\n\n// マップ操作\n// キーバリューペアを追加/更新\nm[\"three\"] = 3\n// 値を取得 (キーが見つからない場合はゼロ値を返す)\nvalue := m[\"one\"]\n// キーバリューペアを削除\ndelete(m, \"two\")\n\n// 存在確認\n// キーが見つからない場合 value=0, exists=false\nvalue, exists := m[\"four\"]\nif exists {\n  // キーが存在する\n}\n\n// マップの反復処理 (ランダムな順序)\nfor key, value := range m {\n  fmt.Println(key, value)\n}\n\n// すべてのキーを取得\nkeys := make([]string, 0, len(m))\nfor k := range m {\n  keys = append(keys, k)\n}\n\n// 一貫した順序のためにキーをソート\nsort.Strings(keys)\nfor _, k := range keys {\n  fmt.Printf(\"%s: %d\\n\", k, m[k])\n}\n\n// マップは参照 (配列のような値ではない)\noriginal := map[string]int{\"one\": 1}\n// 両方が同じマップを参照\ncopy := original\n// 変更は両方の変数を通じて見える\ncopy[\"one\"] = 99"
+      "title": "Implicit Size Array",
+      "code": "// 暗黙的なサイズの配列\n// [4]int - コンパイラが要素数を数える\nc := [...]int{4, 5, 6, 7}"
     },
     {
-      "title": "Structs",
-      "code": "// 構造体型を定義\ntype Person struct {\n  Name    string\n  Age     int\n  Address *Address\n}\n\ntype Address struct {\n  Street string\n  City   string\n}\n\n// 構造体を作成\n// 名前付きフィールド (推奨)\np1 := Person{Name: \"Alice\", Age: 30}\n// 位置指定フィールド (壊れやすい)\np2 := Person{\"Bob\", 25, nil}\n// ゼロ化された Person を割り当て、*Person を返す\np3 := new(Person)\n\n// フィールドへのアクセス\nname := p1.Name\np1.Age = 31\n\n// ネストされた構造体\np4 := Person{\n  Name: \"Charlie\",\n  Age: 35,\n  Address: &Address{\n    Street: \"123 Main St\",\n    City: \"Anytown\",\n  },\n}\ncity := p4.Address.City\n\n// 無名構造体 (一度きりの使用)\npoint := struct {\n  X, Y int\n}{10, 20}\n\n// 無名フィールド (埋め込み)\ntype Employee struct {\n// すべての Person フィールドを埋め込む\n  Person\n  CompanyName string\n  Salary      float64\n}\n\ne := Employee{}\n// Person から昇格したフィールド\ne.Name = \"Dave\"\n// これでも動作する\ne.Person.Name = \"Dave\"\ne.CompanyName = \"Acme\""
+      "title": "Accessing Array Elements",
+      "code": "// 要素へのアクセス\n// 0\nfirst := a[0]\n// 最初の要素を 10 に設定\na[0] = 10"
     },
     {
-      "title": "Sets",
-      "code": "// Go には組み込みのセット型がない\n// 代わりに map[type]bool または map[type]struct{} を使用する\n\n// map[string]bool を使用したセット\nset := make(map[string]bool)\n\n// 要素を追加\nset[\"apple\"] = true\nset[\"banana\"] = true\n\n// メンバーシップを確認\nif set[\"apple\"] {\n  // \"apple\" はセット内にある\n}\n\n// 要素を削除\ndelete(set, \"apple\")\n\n// map[string]struct{} を使用したセット (メモリ効率が良い)\nset := make(map[string]struct{})\n\n// 要素を追加\nset[\"apple\"] = struct{}{}\n\n// メンバーシップを確認\nif _, ok := set[\"apple\"]; ok {\n  // \"apple\" はセット内にある\n}\n\n// セット要素を反復処理\nfor element := range set {\n  fmt.Println(element)\n}\n\n// セット操作\n// 和集合\nunion := make(map[string]struct{})\nfor element := range set1 {\n  union[element] = struct{}{}\n}\nfor element := range set2 {\n  union[element] = struct{}{}\n}\n\n// 積集合\nintersection := make(map[string]struct{})\nfor element := range set1 {\n  if _, ok := set2[element]; ok {\n    intersection[element] = struct{}{}\n  }\n}"
+      "title": "Multi-dimensional Arrays",
+      "code": "// 多次元配列\nmatrix := [2][3]int{\n  {1, 2, 3},\n  {4, 5, 6},\n}\n// 6\nvalue := matrix[1][2]"
     },
     {
-      "title": "Linked Lists",
-      "code": "// Go の標準ライブラリには双方向連結リストの実装が含まれている\n// container/list パッケージ内\n\nimport \"container/list\"\n\n// 新しいリストを作成\nl := list.New()\n\n// 要素を追加\n// 末尾に追加\nl.PushBack(\"last\")\n// 先頭に追加\nl.PushFront(\"first\")\n\n// 要素を挿入\nelem := l.PushBack(\"middle\")\nl.InsertBefore(\"before middle\", elem)\nl.InsertAfter(\"after middle\", elem)\n\n// リストを走査\nfor e := l.Front(); e != nil; e = e.Next() {\n// 値にアクセス\n  fmt.Println(e.Value)\n}\n\n// 要素を削除\n// 特定の要素を削除\nl.Remove(elem)\n\n// カスタム連結リストの実装\ntype Node struct {\n  Value int\n  Next  *Node\n}\n\n// 連結リストを作成\nhead := &Node{Value: 1}\nhead.Next = &Node{Value: 2}\nhead.Next.Next = &Node{Value: 3}\n\n// 走査\nfor current := head; current != nil; current = current.Next {\n  fmt.Println(current.Value)\n}"
+      "title": "Arrays are Values (Copies)",
+      "code": "// 配列は値 (コピー)\noriginal := [3]int{1, 2, 3}\n// 完全なコピーを作成\ncopy := original\n// 元の配列には影響しない\ncopy[0] = 99\n\n// 配列のサイズは型の一部 - これらは異なる型\nvar a1 [5]int\nvar a2 [10]int\n// a1 = a2  // コンパイルエラー - 異なる型"
+    },
+    {
+      "title": "Slice Declaration",
+      "code": "// スライス宣言 (配列の動的サイズのビュー)\n// nil スライス (長さと容量は 0)\nvar s []int"
+    },
+    {
+      "title": "Creating Slices (make)",
+      "code": "// スライスを作成\n// len=5, cap=5, ゼロ値で初期化\ns = make([]int, 5)\n// len=3, cap=10, ゼロ値で初期化\ns = make([]int, 3, 10)"
+    },
+    {
+      "title": "Slice Literals",
+      "code": "// スライスリテラル\n// len=3, cap=3\ns = []int{1, 2, 3}"
+    },
+    {
+      "title": "Slicing Existing Arrays/Slices",
+      "code": "// 既存の配列またはスライスからのスライス\na := [5]int{1, 2, 3, 4, 5}\n// s == []int{2, 3, 4}, len=3, cap=4\ns := a[1:4]"
+    },
+    {
+      "title": "Slice Indexing",
+      "code": "// スライスのインデックス\nfull := []int{1, 2, 3, 4, 5}\n// [2 3 4]   - インデックス 1 から 3 まで (4 は含まない)\ns1 := full[1:4]\n// [1 2 3]   - 開始からインデックス 2 まで\ns2 := full[:3]\n// [3 4 5]   - インデックス 2 から最後まで\ns3 := full[2:]\n// [1 2 3 4 5] - スライス全体\ns4 := full[:]"
+    },
+    {
+      "title": "Appending to Slices",
+      "code": "// スライスに追加 (必要に応じて新しい基底配列を作成することがある)\n// 要素 4 と 5 を追加\ns = append(s, 4, 5)\nt := []int{6, 7, 8}\n// 別のスライスを追加\ns = append(s, t...)"
+    },
+    {
+      "title": "Slice Length and Capacity",
+      "code": "// スライスの長さと容量\n// 要素数\nlen := len(s)\n// 基底配列の容量\ncap := cap(s)"
+    },
+    {
+      "title": "Copying Slices",
+      "code": "// コピー\ndst := make([]int, len(src))\n// src から dst へコピー、コピーされた要素数を返す\ncopy(dst, src)"
+    },
+    {
+      "title": "Deleting from Slices",
+      "code": "// インデックス i の要素を削除\ns = append(s[:i], s[i+1:]...)"
+    },
+    {
+      "title": "Inserting into Slices",
+      "code": "// インデックス i に要素を挿入\ns = append(s[:i], append([]int{x}, s[i:]...)...)\n// より効率的な挿入\n// 末尾にゼロ値を追加\ns = append(s, 0)\n// 要素を右にシフト\ncopy(s[i+1:], s[i:])\n// 新しい要素を配置\ns[i] = x"
+    },
+    {
+      "title": "Map Declaration",
+      "code": "// マップ宣言 (キーバリューストア、順序なし)\n// nil マップ (読み取りは可能だが書き込みは不可)\nvar m map[string]int"
+    },
+    {
+      "title": "Creating Maps (make)",
+      "code": "// マップを作成\nm = make(map[string]int)"
+    },
+    {
+      "title": "Map Literals",
+      "code": "// マップリテラル\nm = map[string]int{\n  \"one\": 1,\n  \"two\": 2,\n}"
+    },
+    {
+      "title": "Map Operations (Add/Update/Get/Delete)",
+      "code": "// マップ操作\n// キーバリューペアを追加/更新\nm[\"three\"] = 3\n// 値を取得 (キーが見つからない場合はゼロ値を返す)\nvalue := m[\"one\"]\n// キーバリューペアを削除\ndelete(m, \"two\")"
+    },
+    {
+      "title": "Checking Map Key Existence",
+      "code": "// 存在確認\n// キーが見つからない場合 value=0, exists=false\nvalue, exists := m[\"four\"]\nif exists {\n  // キーが存在する\n}"
+    },
+    {
+      "title": "Iterating Over Maps",
+      "code": "// マップの反復処理 (ランダムな順序)\nfor key, value := range m {\n  fmt.Println(key, value)\n}"
+    },
+    {
+      "title": "Iterating Over Maps (Sorted Keys)",
+      "code": "// すべてのキーを取得\nkeys := make([]string, 0, len(m))\nfor k := range m {\n  keys = append(keys, k)\n}\n\n// 一貫した順序のためにキーをソート\nsort.Strings(keys)\nfor _, k := range keys {\n  fmt.Printf(\"%s: %d\\n\", k, m[k])\n}"
+    },
+    {
+      "title": "Maps are References",
+      "code": "// マップは参照 (配列のような値ではない)\noriginal := map[string]int{\"one\": 1}\n// 両方が同じマップを参照\ncopy := original\n// 変更は両方の変数を通じて見える\ncopy[\"one\"] = 99"
+    },
+    {
+      "title": "Struct Definition",
+      "code": "// 構造体型を定義\ntype Person struct {\n  Name    string\n  Age     int\n  Address *Address\n}\n\ntype Address struct {\n  Street string\n  City   string\n}"
+    },
+    {
+      "title": "Creating Structs",
+      "code": "// 構造体を作成\n// 名前付きフィールド (推奨)\np1 := Person{Name: \"Alice\", Age: 30}\n// 位置指定フィールド (壊れやすい)\np2 := Person{\"Bob\", 25, nil}\n// ゼロ化された Person を割り当て、*Person を返す\np3 := new(Person)"
+    },
+    {
+      "title": "Accessing Struct Fields",
+      "code": "// フィールドへのアクセス\nname := p1.Name\np1.Age = 31"
+    },
+    {
+      "title": "Nested Structs",
+      "code": "// ネストされた構造体\np4 := Person{\n  Name: \"Charlie\",\n  Age: 35,\n  Address: &Address{\n    Street: \"123 Main St\",\n    City: \"Anytown\",\n  },\n}\ncity := p4.Address.City"
+    },
+    {
+      "title": "Anonymous Structs",
+      "code": "// 無名構造体 (一度きりの使用)\npoint := struct {\n  X, Y int\n}{10, 20}"
+    },
+    {
+      "title": "Embedded Fields (Anonymous Fields)",
+      "code": "// 無名フィールド (埋め込み)\ntype Employee struct {\n// すべての Person フィールドを埋め込む\n  Person\n  CompanyName string\n  Salary      float64\n}\n\ne := Employee{}\n// Person から昇格したフィールド\ne.Name = \"Dave\"\n// これでも動作する\ne.Person.Name = \"Dave\"\ne.CompanyName = \"Acme\""
+    },
+    {
+      "title": "Sets using map[type]bool",
+      "code": "// Go には組み込みのセット型がない\n// 代わりに map[type]bool または map[type]struct{} を使用する\n\n// map[string]bool を使用したセット\nset := make(map[string]bool)\n\n// 要素を追加\nset[\"apple\"] = true\nset[\"banana\"] = true\n\n// メンバーシップを確認\nif set[\"apple\"] {\n  // \"apple\" はセット内にある\n}\n\n// 要素を削除\ndelete(set, \"apple\")"
+    },
+    {
+      "title": "Sets using map[type]struct{}",
+      "code": "// map[string]struct{} を使用したセット (メモリ効率が良い)\nset := make(map[string]struct{})\n\n// 要素を追加\nset[\"apple\"] = struct{}{}\n\n// メンバーシップを確認\nif _, ok := set[\"apple\"]; ok {\n  // \"apple\" はセット内にある\n}\n\n// セット要素を反復処理\nfor element := range set {\n  fmt.Println(element)\n}"
+    },
+    {
+      "title": "Set Operations (Union, Intersection)",
+      "code": "// セット操作\n// 和集合\nunion := make(map[string]struct{})\nfor element := range set1 {\n  union[element] = struct{}{}\n}\nfor element := range set2 {\n  union[element] = struct{}{}\n}\n\n// 積集合\nintersection := make(map[string]struct{})\nfor element := range set1 {\n  if _, ok := set2[element]; ok {\n    intersection[element] = struct{}{}\n  }\n}"
+    },
+    {
+      "title": "Linked Lists (container/list)",
+      "code": "// Go の標準ライブラリには双方向連結リストの実装が含まれている\n// container/list パッケージ内\n\nimport \"container/list\"\n\n// 新しいリストを作成\nl := list.New()\n\n// 要素を追加\n// 末尾に追加\nl.PushBack(\"last\")\n// 先頭に追加\nl.PushFront(\"first\")\n\n// 要素を挿入\nelem := l.PushBack(\"middle\")\nl.InsertBefore(\"before middle\", elem)\nl.InsertAfter(\"after middle\", elem)\n\n// リストを走査\nfor e := l.Front(); e != nil; e = e.Next() {\n// 値にアクセス\n  fmt.Println(e.Value)\n}\n\n// 要素を削除\n// 特定の要素を削除\nl.Remove(elem)"
+    },
+    {
+      "title": "Custom Linked List Implementation",
+      "code": "// カスタム連結リストの実装\ntype Node struct {\n  Value int\n  Next  *Node\n}\n\n// 連結リストを作成\nhead := &Node{Value: 1}\nhead.Next = &Node{Value: 2}\nhead.Next.Next = &Node{Value: 3}\n\n// 走査\nfor current := head; current != nil; current = current.Next {\n  fmt.Println(current.Value)\n}"
     }
   ]
 }

--- a/src/data/go-cheatsheet/error-handling.json
+++ b/src/data/go-cheatsheet/error-handling.json
@@ -2,20 +2,80 @@
   "title": "Error handling",
   "codeExamples": [
     {
-      "title": "Errors",
-      "code": "// Error インターフェース\ntype error interface {\n  Error() string\n}\n\n// エラーの作成\n// テキスト付きの単純なエラー\nerr1 := errors.New(\"something went wrong\")\n\n// フォーマットされたエラー (より一般的)\nerr2 := fmt.Errorf(\"process failed: %s\", detail)\n\n// エラーを返す関数\nfunc divide(a, b int) (int, error) {\n  if b == 0 {\n    return 0, errors.New(\"division by zero\")\n  }\n// nil はエラーがないことを示す\n  return a / b, nil\n}\n\n// エラー処理\nresult, err := divide(10, 2)\nif err != nil {\n  // エラーパス\n  fmt.Println(\"Error:\", err)\n// エラー時の早期リターンは慣用的\n  return\n}\n// 正常系パス\nfmt.Println(\"Result:\", result)\n\n// エラーのラップ (Go 1.13+) でコンテキストを追加\nif err := loadConfig(filename); err != nil {\n  return fmt.Errorf(\"config processing failed: %w\", err)\n}\n\n// エラーは値である\n// 他の値と同様に、保存、返却、チェックが可能\nvar ErrNotFound = errors.New(\"not found\")\n\nfunc findItem(id string) (*Item, error) {\n  // ...\n  return nil, ErrNotFound\n}\n\nif errors.Is(err, ErrNotFound) {\n  // not found ケースを処理\n}"
+      "title": "The error Interface",
+      "code": "// Error インターフェース\ntype error interface {\n  Error() string\n}"
     },
     {
-      "title": "Custom errors",
-      "code": "// カスタムエラー型を定義\ntype MyError struct {\n  Code    int\n  Message string\n}\n\n// Error インターフェースを実装\nfunc (e *MyError) Error() string {\n  return fmt.Sprintf(\"error %d: %s\", e.Code, e.Message)\n}\n\n// カスタムエラーを返す\nfunc doSomething() error {\n  return &MyError{\n    Code:    500,\n    Message: \"something went wrong\",\n  }\n}\n\n// 型アサーションでカスタムエラーフィールドにアクセス\nif err := doSomething(); err != nil {\n  if myErr, ok := err.(*MyError); ok {\n    fmt.Println(\"Code:\", myErr.Code)\n  }\n}\n\n// errors.As (Go 1.13+) を使用した型チェック\nvar myErr *MyError\nif errors.As(err, &myErr) {\n  fmt.Println(\"Code:\", myErr.Code)\n}\n\n// ラップによる階層的なエラーの作成\nfunc request() error {\n  err := connect()\n  if err != nil {\n    return fmt.Errorf(\"request failed: %w\", err)\n  }\n  // ...\n}\n\n// ラップされたエラーのチェック\nif errors.Is(err, ErrConnRefused) {\n  // connection refused エラーを処理\n}"
+      "title": "Creating Errors (errors.New)",
+      "code": "// エラーの作成\n// テキスト付きの単純なエラー\nerr1 := errors.New(\"something went wrong\")"
     },
     {
-      "title": "Error Patterns",
-      "code": "// センチネルエラー (事前定義されたエラー)\nvar (\n  ErrNotFound     = errors.New(\"not found\")\n  ErrUnauthorized = errors.New(\"unauthorized\")\n  ErrTimeout      = errors.New(\"timeout\")\n)\n\n// エラーチェック\nif errors.Is(err, ErrNotFound) {\n  // not found ケースを処理\n}\n\n// 早期リターンによる反復的なチェックの回避\nfunc process() error {\n  err := step1()\n  if err != nil {\n    return fmt.Errorf(\"step1 failed: %w\", err)\n  }\n  \n  err = step2()\n  if err != nil {\n    return fmt.Errorf(\"step2 failed: %w\", err)\n  }\n  \n  return step3()\n}\n\n// エラー処理ミドルウェア (HTTP サーバー用)\nfunc errorHandler(next http.Handler) http.Handler {\n  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n    defer func() {\n      if r := recover(); r != nil {\n        log.Printf(\"panic: %v\", r)\n        http.Error(w, \"internal server error\", http.StatusInternalServerError)\n      }\n    }()\n    next.ServeHTTP(w, r)\n  })\n}\n\n// 構造化エラー (異なるフィールドを持つ)\ntype FieldError struct {\n  Field string\n  Value interface{}\n  Msg   string\n}\n\nfunc (f *FieldError) Error() string {\n  return fmt.Sprintf(\"invalid value %v for field %s: %s\", f.Value, f.Field, f.Msg)\n}"
+      "title": "Creating Errors (fmt.Errorf)",
+      "code": "// フォーマットされたエラー (より一般的)\nerr2 := fmt.Errorf(\"process failed: %s\", detail)"
     },
     {
-      "title": "Error Handling in Go 1.20+",
-      "code": "// 複数のエラーの結合 (Go 1.20+)\nimport \"errors\"\n\n// Join は複数のエラーを単一のエラーに結合する\nfunc validateForm(data Form) error {\n  var errs []error\n  \n  if data.Name == \"\" {\n    errs = append(errs, errors.New(\"name is required\"))\n  }\n  \n  if data.Email == \"\" {\n    errs = append(errs, errors.New(\"email is required\"))\n  }\n  \n  if len(errs) > 0 {\n// 単一のエラーを返す\n    return errors.Join(errs...)\n  }\n  return nil\n}\n\n// 複数のエラーのアンラップ\nerr := validateForm(form)\nvar nameErr *NameError\nif errors.As(err, &nameErr) {\n  // name エラーを処理\n}\n\n// 結合されたエラーの反復処理\nfmt.Println(\"Validation errors:\")\nerrs := make([]error, 0)\nerrors.Unwrap(err, func(e error) bool {\n  errs = append(errs, e)\n// アンラップを続行\n  return true\n})\n\nfor _, e := range errs {\n  fmt.Println(\"-\", e)\n}\n\n// defer を使用したエラー処理\nfunc processFile(filename string) (err error) {\n  f, err := os.Open(filename)\n  if err != nil {\n    return fmt.Errorf(\"failed to open file: %w\", err)\n  }\n  \n  defer func() {\n    closeErr := f.Close()\n    if err == nil && closeErr != nil {\n// 他にエラーがない場合、close エラーを呼び出し元に渡す\n      err = closeErr\n    }\n  }()\n  \n  // ファイルを処理\n  return nil\n}"
+      "title": "Functions Returning Errors",
+      "code": "// エラーを返す関数\nfunc divide(a, b int) (int, error) {\n  if b == 0 {\n    return 0, errors.New(\"division by zero\")\n  }\n// nil はエラーがないことを示す\n  return a / b, nil\n}"
+    },
+    {
+      "title": "Basic Error Handling",
+      "code": "// エラー処理\nresult, err := divide(10, 2)\nif err != nil {\n  // エラーパス\n  fmt.Println(\"Error:\", err)\n// エラー時の早期リターンは慣用的\n  return\n}\n// 正常系パス\nfmt.Println(\"Result:\", result)"
+    },
+    {
+      "title": "Wrapping Errors (%w)",
+      "code": "// エラーのラップ (Go 1.13+) でコンテキストを追加\nif err := loadConfig(filename); err != nil {\n  return fmt.Errorf(\"config processing failed: %w\", err)\n}"
+    },
+    {
+      "title": "Errors as Values (errors.Is)",
+      "code": "// エラーは値である\n// 他の値と同様に、保存、返却、チェックが可能\nvar ErrNotFound = errors.New(\"not found\")\n\nfunc findItem(id string) (*Item, error) {\n  // ...\n  if itemNotFound {\n    return nil, ErrNotFound\n  }\n  return &item, nil\n}\n\nitem, err := findItem(\"some-id\")\nif errors.Is(err, ErrNotFound) {\n  // not found ケースを処理\n  fmt.Println(\"Item not found\")\n}"
+    },
+    {
+      "title": "Defining Custom Error Types",
+      "code": "// カスタムエラー型を定義\ntype MyError struct {\n  Code    int\n  Message string\n}\n\n// Error インターフェースを実装\nfunc (e *MyError) Error() string {\n  return fmt.Sprintf(\"error %d: %s\", e.Code, e.Message)\n}"
+    },
+    {
+      "title": "Returning Custom Errors",
+      "code": "// カスタムエラーを返す\nfunc doSomething() error {\n  // 何らかの条件でエラー発生\n  return &MyError{\n    Code:    500,\n    Message: \"something went wrong\",\n  }\n}"
+    },
+    {
+      "title": "Checking Custom Errors (Type Assertion)",
+      "code": "// 型アサーションでカスタムエラーフィールドにアクセス\nif err := doSomething(); err != nil {\n  if myErr, ok := err.(*MyError); ok {\n    fmt.Println(\"Code:\", myErr.Code)\n  }\n}"
+    },
+    {
+      "title": "Checking Custom Errors (errors.As)",
+      "code": "// errors.As (Go 1.13+) を使用した型チェック\nerr := doSomething()\nvar myErr *MyError\nif errors.As(err, &myErr) {\n  fmt.Println(\"Code:\", myErr.Code)\n}"
+    },
+    {
+      "title": "Checking Wrapped Errors (errors.Is)",
+      "code": "// ラップによる階層的なエラーの作成\nvar ErrConnRefused = errors.New(\"connection refused\")\n\nfunc connect() error {\n  // 接続試行...\n  return ErrConnRefused\n}\n\nfunc request() error {\n  err := connect()\n  if err != nil {\n    return fmt.Errorf(\"request failed: %w\", err)\n  }\n  // ...\n  return nil\n}\n\n// ラップされたエラーのチェック\nerr := request()\nif errors.Is(err, ErrConnRefused) {\n  // connection refused エラーを処理\n  fmt.Println(\"Could not connect\")\n}"
+    },
+    {
+      "title": "Sentinel Errors",
+      "code": "// センチネルエラー (事前定義されたエラー)\nvar (\n  ErrNotFound     = errors.New(\"not found\")\n  ErrUnauthorized = errors.New(\"unauthorized\")\n  ErrTimeout      = errors.New(\"timeout\")\n)\n\n// エラーチェック\nerr := someOperation()\nif errors.Is(err, ErrNotFound) {\n  // not found ケースを処理\n}"
+    },
+    {
+      "title": "Early Return Pattern",
+      "code": "// 早期リターンによる反復的なチェックの回避\nfunc process() error {\n  err := step1()\n  if err != nil {\n    return fmt.Errorf(\"step1 failed: %w\", err)\n  }\n  \n  err = step2()\n  if err != nil {\n    return fmt.Errorf(\"step2 failed: %w\", err)\n  }\n  \n  return step3()\n}"
+    },
+    {
+      "title": "Error Handling Middleware (HTTP)",
+      "code": "// エラー処理ミドルウェア (HTTP サーバー用)\nfunc errorHandler(next http.Handler) http.Handler {\n  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n    defer func() {\n      if r := recover(); r != nil {\n        log.Printf(\"panic: %v\", r)\n        http.Error(w, \"internal server error\", http.StatusInternalServerError)\n      }\n    }()\n    // ここでハンドラからのエラーをキャッチすることもできる\n    // err := next.ServeHTTP(w, r) // ServeHTTP はエラーを返さないが、カスタムハンドラは返すかもしれない\n    next.ServeHTTP(w, r)\n  })\n}"
+    },
+    {
+      "title": "Structured Errors",
+      "code": "// 構造化エラー (異なるフィールドを持つ)\ntype FieldError struct {\n  Field string\n  Value interface{}\n  Msg   string\n}\n\nfunc (f *FieldError) Error() string {\n  return fmt.Sprintf(\"invalid value %v for field %s: %s\", f.Value, f.Field, f.Msg)\n}\n\nfunc validateInput(input string) error {\n  if len(input) < 5 {\n    return &FieldError{Field: \"input\", Value: input, Msg: \"must be at least 5 chars\"}\n  }\n  return nil\n}"
+    },
+    {
+      "title": "Joining Multiple Errors (errors.Join, Go 1.20+)",
+      "code": "// 複数のエラーの結合 (Go 1.20+)\nimport \"errors\"\n\n// Join は複数のエラーを単一のエラーに結合する\nfunc validateForm(data Form) error {\n  var errs []error\n  \n  if data.Name == \"\" {\n    errs = append(errs, errors.New(\"name is required\"))\n  }\n  \n  if data.Email == \"\" {\n    errs = append(errs, errors.New(\"email is required\"))\n  }\n  \n  if len(errs) > 0 {\n// 単一のエラーを返す\n    return errors.Join(errs...)\n  }\n  return nil\n}"
+    },
+    {
+      "title": "Unwrapping Multiple Errors (Go 1.20+)",
+      "code": "// 複数のエラーのアンラップ\nerr := validateForm(form)\n\n// 特定のエラータイプをチェック\nvar nameErr *NameError // カスタムエラータイプと仮定\nif errors.As(err, &nameErr) {\n  // name エラーを処理\n}\n\n// 結合されたエラーの反復処理 (Go 1.20 では errors.Unwrap はこの目的には使用しない)\n// 代わりに、errors.Join によって返されたエラーの Error() メソッドを確認する\nif err != nil {\n  fmt.Println(\"Validation errors:\")\n  // errors.Join は改行でエラーを結合する\n  for _, line := range strings.Split(err.Error(), \"\\n\") {\n    fmt.Println(\"-\", line)\n  }\n}"
+    },
+    {
+      "title": "Error Handling with defer",
+      "code": "// defer を使用したエラー処理 (リソースクリーンアップ)\nfunc processFile(filename string) (err error) {\n  f, err := os.Open(filename)\n  if err != nil {\n    return fmt.Errorf(\"failed to open file: %w\", err)\n  }\n  \n  defer func() {\n    closeErr := f.Close()\n    if err == nil && closeErr != nil {\n// 他にエラーがない場合、close エラーを呼び出し元に渡す\n      err = fmt.Errorf(\"failed to close file: %w\", closeErr)\n    }\n    // 既にエラーがある場合は、元のエラーを保持する\n  }()\n  \n  // ファイルを処理...\n  // _, err = io.Copy(dst, f)\n  // if err != nil {\n  //   return fmt.Errorf(\"failed to process file: %w\", err)\n  // }\n  \n  return nil // 正常終了\n}"
     }
   ]
 }

--- a/src/data/go-cheatsheet/flow-control.json
+++ b/src/data/go-cheatsheet/flow-control.json
@@ -2,24 +2,100 @@
   "title": "Flow control",
   "codeExamples": [
     {
-      "title": "If-else",
-      "code": "// 基本的な if-else\nif x > 10 {\n  // 何かを行う\n} else if x > 5 {\n  // 別の何かを行う\n} else {\n  // さらに別の何かを行う\n}\n\n// 短いステートメント付きの If\nif value := getValue(); value > 10 {\n  // value はこのスコープ内でのみ利用可能\n  // かつ条件が true であった場合\n}\n\n// エラーチェック付きの If (一般的なパターン)\nif err := doSomething(); err != nil {\n  // エラーを処理する\n  return err\n}\n\n// return 後の else を避ける (Go スタイル)\nif condition {\n  // このケースを処理する\n// または break, continue\n  return\n}\n// \"else\" ケースのコードはここから続く"
+      "title": "Basic If-Else",
+      "code": "// 基本的な if-else\nif x > 10 {\n  // 何かを行う\n} else if x > 5 {\n  // 別の何かを行う\n} else {\n  // さらに別の何かを行う\n}"
     },
     {
-      "title": "For loops",
-      "code": "// 標準的な C スタイルの for ループ\nfor i := 0; i < 10; i++ {\n  // ループ本体\n}\n\n// while としての For\nfor condition {\n  // ループ本体\n}\n\n// 無限ループ\nfor {\n  // ループ本体\n  if shouldBreak {\n    break\n  }\n}\n\n// For-range ループ (配列、スライス、文字列、マップ、チャネル)\n// 配列、スライス、文字列: インデックス、値\nfor index, value := range collection {\n  // インデックスと値を使用\n}\n\n// マップ: キー、値\nfor key, value := range myMap {\n  // キーと値を使用\n}\n\n// チャネル: 値のみ\nfor value := range channel {\n  // 値を使用\n}\n\n// アンダースコアでインデックスまたは値をスキップ\nfor _, value := range collection {\n  // 値のみを使用\n}\n\n// インデックスのみ\nfor index := range collection {\n  // インデックスのみを使用\n}"
+      "title": "If with Short Statement",
+      "code": "// 短いステートメント付きの If\nif value := getValue(); value > 10 {\n  // value はこのスコープ内でのみ利用可能\n  // かつ条件が true であった場合\n}"
     },
     {
-      "title": "Switch",
-      "code": "// 基本的な switch (C/Java と異なり自動的なフォールスルーなし)\nswitch value {\ncase 1:\n  // 1 の場合のコード\ncase 2, 3:\n  // 2 または 3 の場合のコード\ndefault:\n  // デフォルトのコード\n}\n\n// 式なしの Switch (if-else チェーンの代替)\nswitch {\ncase x > 100:\n  // x > 100 の場合のコード\ncase x > 10:\n  // x > 10 の場合のコード\ndefault:\n  // デフォルトのコード\n}\n\n// 初期化ステートメント付きの Switch\nswitch os := runtime.GOOS; os {\ncase \"darwin\":\n  fmt.Println(\"OS X\")\ncase \"linux\":\n  fmt.Println(\"Linux\")\ndefault:\n  fmt.Printf(\"%s\\n\", os)\n}\n\n// Fallthrough は次の case の実行を強制する\nswitch n {\ncase 0:\n  fmt.Println(\"zero\")\n  fallthrough\ncase 1:\n  fmt.Println(\"one\")\n  // n が 0 または 1 の場合に実行される\n}\n\n// 型 switch (インターフェース用)\nswitch v := interface{}.(type) {\ncase nil:\n  fmt.Println(\"nil 値\")\ncase int:\n  fmt.Println(\"整数:\", v)\ncase string:\n  fmt.Println(\"文字列:\", v)\ndefault:\n  fmt.Printf(\"予期しない型: %T\\n\", v)\n}"
+      "title": "If with Error Check",
+      "code": "// エラーチェック付きの If (一般的なパターン)\nif err := doSomething(); err != nil {\n  // エラーを処理する\n  return err\n}"
     },
     {
-      "title": "Defer",
-      "code": "// Defer 文は、囲んでいる関数が戻る前に関数を実行する\n// クリーンアップ操作に使用される (ファイル、接続などを閉じる)\nfunc ReadFile(filename string) ([]byte, error) {\n  f, err := os.Open(filename)\n  if err != nil {\n    return nil, err\n  }\n// f.Close() は ReadFile が戻るときに実行される\n  defer f.Close()\n  \n  return io.ReadAll(f)\n}\n\n// 複数の defer は LIFO (後入れ先出し) 順で実行される\nfunc ProcessFiles() {\n  defer fmt.Println(\"1. Done processing\")\n  defer fmt.Println(\"2. Closing files\")\n  defer fmt.Println(\"3. Saving results\")\n  \n  // 関数が戻るときの出力:\n  // 3. Saving results\n  // 2. Closing files\n  // 1. Done processing\n}\n\n// Defer は引数をすぐに評価するが、関数の実行は後で行う\nfunc example() {\n  i := 1\n// \"deferred: 1\" と出力される\n  defer fmt.Println(\"deferred:\", i)\n  i++\n// \"regular: 2\" と出力される\n  fmt.Println(\"regular:\", i)\n}\n\n// 一般的な使用例: Mutex のロック/アンロック\nfunc UpdateData(data *Data) {\n  data.mu.Lock()\n  defer data.mu.Unlock()\n  \n  // データを更新...\n}"
+      "title": "Avoiding Else After Return",
+      "code": "// return 後の else を避ける (Go スタイル)\nif condition {\n  // このケースを処理する\n// または break, continue\n  return\n}\n// \"else\" ケースのコードはここから続く"
     },
     {
-      "title": "Panic and Recover",
-      "code": "// Panic は現在の goroutine の通常の実行を停止する\n// 遅延関数は依然として実行される\nfunc divide(a, b int) int {\n  if b == 0 {\n// 回復されない限りプログラムをクラッシュさせる\n    panic(\"division by zero\")\n  }\n  return a / b\n}\n\n// Recover は panic をキャプチャし、通常の実行を再開する\n// 遅延関数内でのみ有用\nfunc SafeDivide(a, b int) (result int, err error) {\n  // 回復を設定\n  defer func() {\n    if r := recover(); r != nil {\n      // panic をエラーに変換\n      err = fmt.Errorf(\"panic occurred: %v\", r)\n    }\n  }()\n  \n  // b が 0 の場合、これは panic するが、recover がそれをキャッチする\n  result = a / b\n  return result, nil\n}\n\n// 使用例\n// クラッシュする代わりに 0 とエラーを返す\nresult, err := SafeDivide(10, 0)\n\n// ベストプラクティス:\n// 1. 回復不能なエラー (例: 破損) にのみ panic を使用する\n// 2. 通常のエラー処理では、panic/recover ではなくエラーリターンを使用すべき\n// 3. 予期される panic からのみ回復する"
+      "title": "Standard For Loop",
+      "code": "// 標準的な C スタイルの for ループ\nfor i := 0; i < 10; i++ {\n  // ループ本体\n}"
+    },
+    {
+      "title": "For as While",
+      "code": "// while としての For\nfor condition {\n  // ループ本体\n}"
+    },
+    {
+      "title": "Infinite Loop",
+      "code": "// 無限ループ\nfor {\n  // ループ本体\n  if shouldBreak {\n    break\n  }\n}"
+    },
+    {
+      "title": "For-Range (Arrays, Slices, Strings)",
+      "code": "// For-range ループ (配列、スライス、文字列、マップ、チャネル)\n// 配列、スライス、文字列: インデックス、値\nfor index, value := range collection {\n  // インデックスと値を使用\n}"
+    },
+    {
+      "title": "For-Range (Maps)",
+      "code": "// マップ: キー、値\nfor key, value := range myMap {\n  // キーと値を使用\n}"
+    },
+    {
+      "title": "For-Range (Channels)",
+      "code": "// チャネル: 値のみ\nfor value := range channel {\n  // 値を使用\n}"
+    },
+    {
+      "title": "For-Range (Skipping Index/Value)",
+      "code": "// アンダースコアでインデックスまたは値をスキップ\nfor _, value := range collection {\n  // 値のみを使用\n}\n\n// インデックスのみ\nfor index := range collection {\n  // インデックスのみを使用\n}"
+    },
+    {
+      "title": "Basic Switch",
+      "code": "// 基本的な switch (C/Java と異なり自動的なフォールスルーなし)\nswitch value {\ncase 1:\n  // 1 の場合のコード\ncase 2, 3:\n  // 2 または 3 の場合のコード\ndefault:\n  // デフォルトのコード\n}"
+    },
+    {
+      "title": "Switch without Expression",
+      "code": "// 式なしの Switch (if-else チェーンの代替)\nswitch {\ncase x > 100:\n  // x > 100 の場合のコード\ncase x > 10:\n  // x > 10 の場合のコード\ndefault:\n  // デフォルトのコード\n}"
+    },
+    {
+      "title": "Switch with Initialization",
+      "code": "// 初期化ステートメント付きの Switch\nswitch os := runtime.GOOS; os {\ncase \"darwin\":\n  fmt.Println(\"OS X\")\ncase \"linux\":\n  fmt.Println(\"Linux\")\ndefault:\n  fmt.Printf(\"%s\\n\", os)\n}"
+    },
+    {
+      "title": "Switch Fallthrough",
+      "code": "// Fallthrough は次の case の実行を強制する\nswitch n {\ncase 0:\n  fmt.Println(\"zero\")\n  fallthrough\ncase 1:\n  fmt.Println(\"one\")\n  // n が 0 または 1 の場合に実行される\n}"
+    },
+    {
+      "title": "Type Switch",
+      "code": "// 型 switch (インターフェース用)\nswitch v := interface{}.(type) {\ncase nil:\n  fmt.Println(\"nil 値\")\ncase int:\n  fmt.Println(\"整数:\", v)\ncase string:\n  fmt.Println(\"文字列:\", v)\ndefault:\n  fmt.Printf(\"予期しない型: %T\\n\", v)\n}"
+    },
+    {
+      "title": "Defer for Cleanup",
+      "code": "// Defer 文は、囲んでいる関数が戻る前に関数を実行する\n// クリーンアップ操作に使用される (ファイル、接続などを閉じる)\nfunc ReadFile(filename string) ([]byte, error) {\n  f, err := os.Open(filename)\n  if err != nil {\n    return nil, err\n  }\n// f.Close() は ReadFile が戻るときに実行される\n  defer f.Close()\n  \n  return io.ReadAll(f)\n}"
+    },
+    {
+      "title": "Multiple Defers (LIFO)",
+      "code": "// 複数の defer は LIFO (後入れ先出し) 順で実行される\nfunc ProcessFiles() {\n  defer fmt.Println(\"1. Done processing\")\n  defer fmt.Println(\"2. Closing files\")\n  defer fmt.Println(\"3. Saving results\")\n  \n  // 関数が戻るときの出力:\n  // 3. Saving results\n  // 2. Closing files\n  // 1. Done processing\n}"
+    },
+    {
+      "title": "Defer Argument Evaluation",
+      "code": "// Defer は引数をすぐに評価するが、関数の実行は後で行う\nfunc example() {\n  i := 1\n// \"deferred: 1\" と出力される\n  defer fmt.Println(\"deferred:\", i)\n  i++\n// \"regular: 2\" と出力される\n  fmt.Println(\"regular:\", i)\n}"
+    },
+    {
+      "title": "Defer with Mutex",
+      "code": "// 一般的な使用例: Mutex のロック/アンロック\nfunc UpdateData(data *Data) {\n  data.mu.Lock()\n  defer data.mu.Unlock()\n  \n  // データを更新...\n}"
+    },
+    {
+      "title": "Panic",
+      "code": "// Panic は現在の goroutine の通常の実行を停止する\n// 遅延関数は依然として実行される\nfunc divide(a, b int) int {\n  if b == 0 {\n// 回復されない限りプログラムをクラッシュさせる\n    panic(\"division by zero\")\n  }\n  return a / b\n}"
+    },
+    {
+      "title": "Recover",
+      "code": "// Recover は panic をキャプチャし、通常の実行を再開する\n// 遅延関数内でのみ有用\nfunc SafeDivide(a, b int) (result int, err error) {\n  // 回復を設定\n  defer func() {\n    if r := recover(); r != nil {\n      // panic をエラーに変換\n      err = fmt.Errorf(\"panic occurred: %v\", r)\n    }\n  }()\n  \n  // b が 0 の場合、これは panic するが、recover がそれをキャッチする\n  result = a / b\n  return result, nil\n}"
+    },
+    {
+      "title": "Panic/Recover Usage",
+      "code": "// 使用例\n// クラッシュする代わりに 0 とエラーを返す\nresult, err := SafeDivide(10, 0)"
+    },
+    {
+      "title": "Panic/Recover Best Practices",
+      "code": "// ベストプラクティス:\n// 1. 回復不能なエラー (例: 破損) にのみ panic を使用する\n// 2. 通常のエラー処理では、panic/recover ではなくエラーリターンを使用すべき\n// 3. 予期される panic からのみ回復する"
     }
   ]
 }

--- a/src/data/go-cheatsheet/functions.json
+++ b/src/data/go-cheatsheet/functions.json
@@ -2,20 +2,80 @@
   "title": "Functions",
   "codeExamples": [
     {
-      "title": "Basic Function",
-      "code": "// 関数宣言\nfunc add(a int, b int) int {\n  return a + b\n}\n\n// 同じ型のパラメータはグループ化できる\nfunc add(a, b int) int {\n  return a + b\n}\n\n// 複数の戻り値\nfunc divAndRemainder(a, b int) (int, int) {\n  return a / b, a % b\n}\n\n// 名前付き戻り値\nfunc split(sum int) (x, y int) {\n  x = sum * 4 / 9\n  y = sum - x\n// naked return は名前付き戻り値を使用する\n  return\n}\n\n// エラーを返す (一般的なパターン)\nfunc readConfig(path string) ([]byte, error) {\n  file, err := os.Open(path)\n  if err != nil {\n// ゼロ値とエラーを返す\n    return nil, err\n  }\n  defer file.Close()\n  \n// データと nil エラーを返す\n  return io.ReadAll(file)\n}"
+      "title": "Function Declaration",
+      "code": "// 関数宣言\nfunc add(a int, b int) int {\n  return a + b\n}"
     },
     {
-      "title": "Variadic Functions",
-      "code": "// 可変長引数関数 (可変数の引数を受け入れる)\nfunc sum(nums ...int) int {\n  total := 0\n  for _, num := range nums {\n    total += num\n  }\n  return total\n}\n\n// 可変長引数関数の呼び出し\n// 10\ntotal := sum(1, 2, 3, 4)\n\n// スライスの展開\nnumbers := []int{1, 2, 3, 4}\n// 10\ntotal = sum(numbers...)\n\n// 他のパラメータを持つ可変長引数\nfunc appendValues(slice []int, values ...int) []int {\n  return append(slice, values...)\n}\n\nslice := []int{1, 2}\n// [1 2 3 4 5]\nslice = appendValues(slice, 3, 4, 5)\n\n// 便利な標準ライブラリの例:\n// fmt.Printf(format string, a ...interface{})\n// log.Printf(format string, a ...interface{})\n// errors.Join(errs ...error) error"
+      "title": "Grouped Parameters",
+      "code": "// 同じ型のパラメータはグループ化できる\nfunc add(a, b int) int {\n  return a + b\n}"
     },
     {
-      "title": "Closures",
-      "code": "// 関数を返す関数 (クロージャ)\nfunc adder() func(int) int {\n// この変数は「キャプチャされる」\n  sum := 0\n  return func(x int) int {\n// キャプチャされた変数を変更する\n    sum += x\n    return sum\n  }\n}\n\n// クロージャの使用\npos := adder()\n// 10\nresult := pos(10)\n// 30\nresult = pos(20)\n// 60\nresult = pos(30)\n\n// 異なるインスタンスは異なる状態を持つ\npos1 := adder()\npos2 := adder()\n// 10\nfmt.Println(pos1(10))\n// 20\nfmt.Println(pos2(20))\n// 50\nfmt.Println(pos1(40))\n\n// for ループでのクロージャの使用 (よくある落とし穴)\nfuncs := make([]func(), 3)\nfor i := 0; i < 3; i++ {\n// 間違い: すべて最後の i の値 (3) を出力する\n  funcs[i] = func() { fmt.Println(i) }\n}\n\n// 正しいアプローチ: 各反復で新しい変数を作成する\nfuncs := make([]func(), 3)\nfor i := 0; i < 3; i++ {\n// このスコープで新しい i を作成\n  i := i\n// 正しい: それぞれが自身の i を出力する\n  funcs[i] = func() { fmt.Println(i) }\n}"
+      "title": "Multiple Return Values",
+      "code": "// 複数の戻り値\nfunc divAndRemainder(a, b int) (int, int) {\n  return a / b, a % b\n}"
     },
     {
-      "title": "Function Types",
-      "code": "// 関数は第一級の値\n// 変数に代入したり、引数として渡したり、関数から返したりできる\n\n// 関数型の宣言\ntype Handler func(string) error\n\n// 変数としての関数\nvar compute func(int, int) int\ncompute = func(a, b int) int {\n  return a + b\n}\n// 8\nresult := compute(5, 3)\n\n// 引数としての関数\nfunc process(apply func(int, int) int, a, b int) int {\n  return apply(a, b)\n}\n// 15\nresult := process(func(x, y int) int { return x * y }, 5, 3)\n\n// 戻り値としての関数\nfunc multiplier(factor int) func(int) int {\n  return func(n int) int {\n    return n * factor\n  }\n}\ndouble := multiplier(2)\ntriple := multiplier(3)\n// 10\nfmt.Println(double(5))\n// 15\nfmt.Println(triple(5))"
+      "title": "Named Return Values",
+      "code": "// 名前付き戻り値\nfunc split(sum int) (x, y int) {\n  x = sum * 4 / 9\n  y = sum - x\n// naked return は名前付き戻り値を使用する\n  return\n}"
+    },
+    {
+      "title": "Returning Errors",
+      "code": "// エラーを返す (一般的なパターン)\nfunc readConfig(path string) ([]byte, error) {\n  file, err := os.Open(path)\n  if err != nil {\n// ゼロ値とエラーを返す\n    return nil, err\n  }\n  defer file.Close()\n  \n// データと nil エラーを返す\n  return io.ReadAll(file)\n}"
+    },
+    {
+      "title": "Variadic Function Definition",
+      "code": "// 可変長引数関数 (可変数の引数を受け入れる)\nfunc sum(nums ...int) int {\n  total := 0\n  for _, num := range nums {\n    total += num\n  }\n  return total\n}"
+    },
+    {
+      "title": "Calling Variadic Functions",
+      "code": "// 可変長引数関数の呼び出し\n// 10\ntotal := sum(1, 2, 3, 4)"
+    },
+    {
+      "title": "Slicing Variadic Arguments",
+      "code": "// スライスの展開\nnumbers := []int{1, 2, 3, 4}\n// 10\ntotal = sum(numbers...)"
+    },
+    {
+      "title": "Variadic with Other Parameters",
+      "code": "// 他のパラメータを持つ可変長引数\nfunc appendValues(slice []int, values ...int) []int {\n  return append(slice, values...)\n}\n\nslice := []int{1, 2}\n// [1 2 3 4 5]\nslice = appendValues(slice, 3, 4, 5)"
+    },
+    {
+      "title": "Standard Library Variadic Examples",
+      "code": "// 便利な標準ライブラリの例:\n// fmt.Printf(format string, a ...interface{})\n// log.Printf(format string, a ...interface{})\n// errors.Join(errs ...error) error"
+    },
+    {
+      "title": "Closure Definition",
+      "code": "// 関数を返す関数 (クロージャ)\nfunc adder() func(int) int {\n// この変数は「キャプチャされる」\n  sum := 0\n  return func(x int) int {\n// キャプチャされた変数を変更する\n    sum += x\n    return sum\n  }\n}"
+    },
+    {
+      "title": "Using Closures",
+      "code": "// クロージャの使用\npos := adder()\n// 10\nresult := pos(10)\n// 30\nresult = pos(20)\n// 60\nresult = pos(30)"
+    },
+    {
+      "title": "Closure State",
+      "code": "// 異なるインスタンスは異なる状態を持つ\npos1 := adder()\npos2 := adder()\n// 10\nfmt.Println(pos1(10))\n// 20\nfmt.Println(pos2(20))\n// 50\nfmt.Println(pos1(40))"
+    },
+    {
+      "title": "Closures in Loops (Pitfall)",
+      "code": "// for ループでのクロージャの使用 (よくある落とし穴)\nfuncs := make([]func(), 3)\nfor i := 0; i < 3; i++ {\n// 間違い: すべて最後の i の値 (3) を出力する\n  funcs[i] = func() { fmt.Println(i) }\n}"
+    },
+    {
+      "title": "Closures in Loops (Correct)",
+      "code": "// 正しいアプローチ: 各反復で新しい変数を作成する\nfuncs := make([]func(), 3)\nfor i := 0; i < 3; i++ {\n// このスコープで新しい i を作成\n  i := i\n// 正しい: それぞれが自身の i を出力する\n  funcs[i] = func() { fmt.Println(i) }\n}"
+    },
+    {
+      "title": "Function Type Declaration",
+      "code": "// 関数は第一級の値\n// 変数に代入したり、引数として渡したり、関数から返したりできる\n\n// 関数型の宣言\ntype Handler func(string) error"
+    },
+    {
+      "title": "Function as Variable",
+      "code": "// 変数としての関数\nvar compute func(int, int) int\ncompute = func(a, b int) int {\n  return a + b\n}\n// 8\nresult := compute(5, 3)"
+    },
+    {
+      "title": "Function as Argument",
+      "code": "// 引数としての関数\nfunc process(apply func(int, int) int, a, b int) int {\n  return apply(a, b)\n}\n// 15\nresult := process(func(x, y int) int { return x * y }, 5, 3)"
+    },
+    {
+      "title": "Function as Return Value",
+      "code": "// 戻り値としての関数\nfunc multiplier(factor int) func(int) int {\n  return func(n int) int {\n    return n * factor\n  }\n}\ndouble := multiplier(2)\ntriple := multiplier(3)\n// 10\nfmt.Println(double(5))\n// 15\nfmt.Println(triple(5))"
     },
     {
       "title": "Method vs Function",

--- a/src/data/go-cheatsheet/generics.json
+++ b/src/data/go-cheatsheet/generics.json
@@ -2,24 +2,48 @@
   "title": "Generics (Go 1.18+)",
   "codeExamples": [
     {
-      "title": "Type Parameters",
-      "code": "// Go 1.18 で導入されたジェネリクスの構文\n\n// 型パラメータ T を持つジェネリック関数\nfunc Print[T any](value T) {\n  fmt.Println(value)\n}\n\n// 使用法\n// T は int\nPrint(42)\n// T は string\nPrint(\"hello\")\n// T は []float64\nPrint([]float64{1.1, 2.2})\n\n// 複数の型パラメータ\nfunc Map[T, U any](s []T, f func(T) U) []U {\n  result := make([]U, len(s))\n  for i, v := range s {\n    result[i] = f(v)\n  }\n  return result\n}\n\n// 使用法\nnums := []int{1, 2, 3}\nsquares := Map(nums, func(x int) int { return x * x })\nstrings := Map(nums, func(x int) string { return fmt.Sprintf(\"#%d\", x) })"
+      "title": "Generic Function with Type Parameter",
+      "code": "// Go 1.18 で導入されたジェネリクスの構文\n\n// 型パラメータ T を持つジェネリック関数\nfunc Print[T any](value T) {\n  fmt.Println(value)\n}\n\n// 使用法\n// T は int\nPrint(42)\n// T は string\nPrint(\"hello\")\n// T は []float64\nPrint([]float64{1.1, 2.2})"
     },
     {
-      "title": "Type Constraints",
-      "code": "// 型制約は使用できる型を制限する\n\n// 型要素を持つインターフェースを使用した制約\ntype Numeric interface {\n  int | int8 | int16 | int32 | int64 |\n  uint | uint8 | uint16 | uint32 | uint64 |\n  float32 | float64\n}\n\n// 制約付きのジェネリック関数\nfunc Sum[T Numeric](values []T) T {\n  var sum T\n  for _, v := range values {\n    sum += v\n  }\n  return sum\n}\n\n// 使用法\n// 動作する: int は Numeric を満たす\nSum([]int{1, 2, 3})\n// 動作する: float64 は Numeric を満たす\nSum([]float64{1.1, 2.2, 3.3})\n// Sum([]string{\"a\", \"b\"})    // コンパイルエラー: string は Numeric を満たさない\n\n// golang.org/x/exp/constraints から事前定義された制約を使用する\nimport \"golang.org/x/exp/constraints\"\n\nfunc Max[T constraints.Ordered](a, b T) T {\n  if a > b {\n    return a\n  }\n  return b\n}\n\n// 使用法\n// int で動作する\nMax(5, 10)\n// string で動作する (文字列は順序付け可能)\nMax(\"a\", \"b\")"
+      "title": "Generic Function with Multiple Type Parameters",
+      "code": "// 複数の型パラメータ\nfunc Map[T, U any](s []T, f func(T) U) []U {\n  result := make([]U, len(s))\n  for i, v := range s {\n    result[i] = f(v)\n  }\n  return result\n}\n\n// 使用法\nnums := []int{1, 2, 3}\nsquares := Map(nums, func(x int) int { return x * x })\nstrings := Map(nums, func(x int) string { return fmt.Sprintf(\"#%d\", x) })"
     },
     {
-      "title": "Generic Data Structures",
-      "code": "// ジェネリックデータ構造\n\n// ジェネリックスタック\ntype Stack[T any] struct {\n  items []T\n}\n\nfunc (s *Stack[T]) Push(item T) {\n  s.items = append(s.items, item)\n}\n\nfunc (s *Stack[T]) Pop() (T, bool) {\n  var zero T\n  if len(s.items) == 0 {\n    return zero, false\n  }\n  \n  n := len(s.items) - 1\n  item := s.items[n]\n  s.items = s.items[:n]\n  return item, true\n}\n\n// 使用法\nintStack := Stack[int]{}\nintStack.Push(10)\nintStack.Push(20)\n// val=20, ok=true\nval, ok := intStack.Pop()\n\nstrStack := Stack[string]{}\nstrStack.Push(\"hello\")\n// val2=\"hello\", ok=true\nval2, ok := strStack.Pop()\n\n// 型安全なキーと値を持つジェネリックマップ\ntype SafeMap[K comparable, V any] struct {\n  data map[K]V\n  mu   sync.RWMutex\n}\n\nfunc NewSafeMap[K comparable, V any]() *SafeMap[K, V] {\n  return &SafeMap[K, V]{\n    data: make(map[K]V),\n  }\n}\n\nfunc (m *SafeMap[K, V]) Set(key K, value V) {\n  m.mu.Lock()\n  defer m.mu.Unlock()\n  m.data[key] = value\n}\n\nfunc (m *SafeMap[K, V]) Get(key K) (V, bool) {\n  m.mu.RLock()\n  defer m.mu.RUnlock()\n  val, ok := m.data[key]\n  return val, ok\n}"
+      "title": "Type Constraints using Interfaces",
+      "code": "// 型制約は使用できる型を制限する\n\n// 型要素を持つインターフェースを使用した制約\ntype Numeric interface {\n  int | int8 | int16 | int32 | int64 |\n  uint | uint8 | uint16 | uint32 | uint64 |\n  float32 | float64\n}\n\n// 制約付きのジェネリック関数\nfunc Sum[T Numeric](values []T) T {\n  var sum T\n  for _, v := range values {\n    sum += v\n  }\n  return sum\n}\n\n// 使用法\n// 動作する: int は Numeric を満たす\nSum([]int{1, 2, 3})\n// 動作する: float64 は Numeric を満たす\nSum([]float64{1.1, 2.2, 3.3})\n// Sum([]string{\"a\", \"b\"})    // コンパイルエラー: string は Numeric を満たさない"
     },
     {
-      "title": "Type Parameter Methods",
-      "code": "// 型パラメータメソッドと型推論\n\n// メソッドを持つ型制約\ntype Stringer interface {\n  String() string\n}\n\nfunc Join[T Stringer](values []T, sep string) string {\n  result := \"\"\n  for i, v := range values {\n    if i > 0 {\n      result += sep\n    }\n    result += v.String()\n  }\n  return result\n}\n\n// Stringer を実装\ntype Person struct {\n  Name string\n  Age  int\n}\n\nfunc (p Person) String() string {\n  return fmt.Sprintf(\"%s (%d)\", p.Name, p.Age)\n}\n\n// 使用法\npeople := []Person{\n  {\"Alice\", 30},\n  {\"Bob\", 25},\n}\n// \"Alice (30), Bob (25)\"\nfmt.Println(Join(people, \", \"))\n\n// メソッドと型セットを持つ型制約\ntype Comparable[T any] interface {\n  CompareTo(T) int\n}\n\nfunc Sort[T Comparable[T]](items []T) {\n  for i := range items {\n    for j := i + 1; j < len(items); j++ {\n      if items[i].CompareTo(items[j]) > 0 {\n        items[i], items[j] = items[j], items[i]\n      }\n    }\n  }\n}\n\n// Comparable を実装\ntype Version struct {\n  Major, Minor, Patch int\n}\n\nfunc (v Version) CompareTo(other Version) int {\n  if v.Major != other.Major {\n    return v.Major - other.Major\n  }\n  if v.Minor != other.Minor {\n    return v.Minor - other.Minor\n  }\n  return v.Patch - other.Patch\n}"
+      "title": "Predefined Constraints (constraints.Ordered)",
+      "code": "// golang.org/x/exp/constraints から事前定義された制約を使用する\nimport \"golang.org/x/exp/constraints\"\n\nfunc Max[T constraints.Ordered](a, b T) T {\n  if a > b {\n    return a\n  }\n  return b\n}\n\n// 使用法\n// int で動作する\nMax(5, 10)\n// string で動作する (文字列は順序付け可能)\nMax(\"a\", \"b\")"
     },
     {
-      "title": "Generic Patterns",
-      "code": "// 一般的なジェネリックパターンとイディオム\n\n// 1. ジェネリック Optional/Maybe 型\ntype Optional[T any] struct {\n  value T\n  valid bool\n}\n\nfunc Some[T any](value T) Optional[T] {\n  return Optional[T]{value: value, valid: true}\n}\n\nfunc None[T any]() Optional[T] {\n  return Optional[T]{valid: false}\n}\n\nfunc (o Optional[T]) IsPresent() bool {\n  return o.valid\n}\n\nfunc (o Optional[T]) Get() (T, bool) {\n  return o.value, o.valid\n}\n\n// 2. エラー処理のためのジェネリック Result 型\ntype Result[T any] struct {\n  value T\n  err   error\n}\n\nfunc Success[T any](value T) Result[T] {\n  return Result[T]{value: value}\n}\n\nfunc Failure[T any](err error) Result[T] {\n  return Result[T]{err: err}\n}\n\nfunc (r Result[T]) IsOk() bool {\n  return r.err == nil\n}\n\nfunc (r Result[T]) Value() T {\n  return r.value\n}\n\nfunc (r Result[T]) Error() error {\n  return r.err\n}\n\n// 3. ジェネリック Min/Max 関数\nfunc Min[T constraints.Ordered](a, b T) T {\n  if a < b {\n    return a\n  }\n  return b\n}\n\nfunc Max[T constraints.Ordered](a, b T) T {\n  if a > b {\n    return a\n  }\n  return b\n}"
+      "title": "Generic Stack",
+      "code": "// ジェネリックデータ構造\n\n// ジェネリックスタック\ntype Stack[T any] struct {\n  items []T\n}\n\nfunc (s *Stack[T]) Push(item T) {\n  s.items = append(s.items, item)\n}\n\nfunc (s *Stack[T]) Pop() (T, bool) {\n  var zero T\n  if len(s.items) == 0 {\n    return zero, false\n  }\n  \n  n := len(s.items) - 1\n  item := s.items[n]\n  s.items = s.items[:n]\n  return item, true\n}\n\n// 使用法\nintStack := Stack[int]{}\nintStack.Push(10)\nintStack.Push(20)\n// val=20, ok=true\nval, ok := intStack.Pop()\n\nstrStack := Stack[string]{}\nstrStack.Push(\"hello\")\n// val2=\"hello\", ok=true\nval2, ok := strStack.Pop()"
+    },
+    {
+      "title": "Generic Safe Map",
+      "code": "// 型安全なキーと値を持つジェネリックマップ\ntype SafeMap[K comparable, V any] struct {\n  data map[K]V\n  mu   sync.RWMutex\n}\n\nfunc NewSafeMap[K comparable, V any]() *SafeMap[K, V] {\n  return &SafeMap[K, V]{\n    data: make(map[K]V),\n  }\n}\n\nfunc (m *SafeMap[K, V]) Set(key K, value V) {\n  m.mu.Lock()\n  defer m.mu.Unlock()\n  m.data[key] = value\n}\n\nfunc (m *SafeMap[K, V]) Get(key K) (V, bool) {\n  m.mu.RLock()\n  defer m.mu.RUnlock()\n  val, ok := m.data[key]\n  return val, ok\n}"
+    },
+    {
+      "title": "Method Constraints (Stringer)",
+      "code": "// 型パラメータメソッドと型推論\n\n// メソッドを持つ型制約\ntype Stringer interface {\n  String() string\n}\n\nfunc Join[T Stringer](values []T, sep string) string {\n  result := \"\"\n  for i, v := range values {\n    if i > 0 {\n      result += sep\n    }\n    result += v.String()\n  }\n  return result\n}\n\n// Stringer を実装\ntype Person struct {\n  Name string\n  Age  int\n}\n\nfunc (p Person) String() string {\n  return fmt.Sprintf(\"%s (%d)\", p.Name, p.Age)\n}\n\n// 使用法\npeople := []Person{\n  {\"Alice\", 30},\n  {\"Bob\", 25},\n}\n// \"Alice (30), Bob (25)\"\nfmt.Println(Join(people, \", \"))"
+    },
+    {
+      "title": "Method Constraints (Comparable)",
+      "code": "// メソッドと型セットを持つ型制約\ntype Comparable[T any] interface {\n  CompareTo(T) int\n}\n\nfunc Sort[T Comparable[T]](items []T) {\n  for i := range items {\n    for j := i + 1; j < len(items); j++ {\n      if items[i].CompareTo(items[j]) > 0 {\n        items[i], items[j] = items[j], items[i]\n      }\n    }\n  }\n}\n\n// Comparable を実装\ntype Version struct {\n  Major, Minor, Patch int\n}\n\nfunc (v Version) CompareTo(other Version) int {\n  if v.Major != other.Major {\n    return v.Major - other.Major\n  }\n  if v.Minor != other.Minor {\n    return v.Minor - other.Minor\n  }\n  return v.Patch - other.Patch\n}"
+    },
+    {
+      "title": "Generic Optional/Maybe Type",
+      "code": "// 一般的なジェネリックパターンとイディオム\n\n// 1. ジェネリック Optional/Maybe 型\ntype Optional[T any] struct {\n  value T\n  valid bool\n}\n\nfunc Some[T any](value T) Optional[T] {\n  return Optional[T]{value: value, valid: true}\n}\n\nfunc None[T any]() Optional[T] {\n  return Optional[T]{valid: false}\n}\n\nfunc (o Optional[T]) IsPresent() bool {\n  return o.valid\n}\n\nfunc (o Optional[T]) Get() (T, bool) {\n  return o.value, o.valid\n}"
+    },
+    {
+      "title": "Generic Result Type",
+      "code": "// 2. エラー処理のためのジェネリック Result 型\ntype Result[T any] struct {\n  value T\n  err   error\n}\n\nfunc Success[T any](value T) Result[T] {\n  return Result[T]{value: value}\n}\n\nfunc Failure[T any](err error) Result[T] {\n  return Result[T]{err: err}\n}\n\nfunc (r Result[T]) IsOk() bool {\n  return r.err == nil\n}\n\nfunc (r Result[T]) Value() T {\n  return r.value\n}\n\nfunc (r Result[T]) Error() error {\n  return r.err\n}"
+    },
+    {
+      "title": "Generic Min/Max Functions",
+      "code": "// 3. ジェネリック Min/Max 関数\nfunc Min[T constraints.Ordered](a, b T) T {\n  if a < b {\n    return a\n  }\n  return b\n}\n\nfunc Max[T constraints.Ordered](a, b T) T {\n  if a > b {\n    return a\n  }\n  return b\n}"
     }
   ]
 }

--- a/src/data/go-cheatsheet/interfaces.json
+++ b/src/data/go-cheatsheet/interfaces.json
@@ -2,28 +2,92 @@
   "title": "Interfaces",
   "codeExamples": [
     {
-      "title": "Defining Interfaces",
-      "code": "// インターフェース定義 - メソッドシグネチャのセット\ntype Shape interface {\n  Area() float64\n  Perimeter() float64\n}\n\n// インターフェースを実装する型\ntype Rectangle struct {\n  Width, Height float64\n}\n\nfunc (r Rectangle) Area() float64 {\n  return r.Width * r.Height\n}\n\nfunc (r Rectangle) Perimeter() float64 {\n  return 2 * (r.Width + r.Height)\n}\n\ntype Circle struct {\n  Radius float64\n}\n\nfunc (c Circle) Area() float64 {\n  return math.Pi * c.Radius * c.Radius\n}\n\nfunc (c Circle) Perimeter() float64 {\n  return 2 * math.Pi * c.Radius\n}\n\n// インターフェースの使用\nfunc printShapeInfo(s Shape) {\n  fmt.Printf(\"Area: %f, Perimeter: %f\\n\", \n    s.Area(), s.Perimeter())\n}\n\nrect := Rectangle{5, 10}\n// 暗黙的に Shape を満たす\nprintShapeInfo(rect)\n\ncirc := Circle{5}\n// これも Shape を満たす\nprintShapeInfo(circ)"
+      "title": "Interface Definition",
+      "code": "// インターフェース定義 - メソッドシグネチャのセット\ntype Shape interface {\n  Area() float64\n  Perimeter() float64\n}"
     },
     {
-      "title": "Interface Values",
-      "code": "// インターフェース値は 2 ワード構造:\n// 1. 型情報へのポインタ (型記述子)\n// 2. 実際のデータへのポインタ (値)\n\n// nil インターフェース\n// ゼロ値は nil\nvar s Shape\n// true\nfmt.Println(s == nil)\n\n// 具体的な値を持つインターフェース\n// s は型情報と値を含む\ns = Rectangle{5, 10}\n// \"main.Rectangle\"\nfmt.Printf(\"%T\\n\", s)\n\n// nil 値を持つインターフェース (ただし型は定義されている)\nvar p *Rectangle = nil\n// s は型情報を持つが値は nil\ns = p\n// false - インターフェース値は nil ではない\nfmt.Println(s == nil)\n// \"*main.Rectangle\"\nfmt.Printf(\"%T\\n\", s)\n\n// 型アサーション\n// Rectangle であれば具体的な値を抽出\nrect, ok := s.(Rectangle)\nif ok {\n  fmt.Println(\"It's a rectangle:\", rect)\n}\n\n// 型スイッチ\nswitch v := s.(type) {\ncase Rectangle:\n  fmt.Println(\"Rectangle with area:\", v.Area())\ncase Circle:\n  fmt.Println(\"Circle with radius:\", v.Radius)\ncase nil:\n  fmt.Println(\"nil shape\")\ndefault:\n  fmt.Println(\"Unknown shape\")\n}"
+      "title": "Implementing Interfaces",
+      "code": "// インターフェースを実装する型\ntype Rectangle struct {\n  Width, Height float64\n}\n\nfunc (r Rectangle) Area() float64 {\n  return r.Width * r.Height\n}\n\nfunc (r Rectangle) Perimeter() float64 {\n  return 2 * (r.Width + r.Height)\n}\n\ntype Circle struct {\n  Radius float64\n}\n\nfunc (c Circle) Area() float64 {\n  return math.Pi * c.Radius * c.Radius\n}\n\nfunc (c Circle) Perimeter() float64 {\n  return 2 * math.Pi * c.Radius\n}"
     },
     {
-      "title": "Empty Interface",
-      "code": "// 空インターフェース (interface{} または Go 1.18+ の any) は任意の値を保持できる\n// または: var i any (Go 1.18+)\nvar i interface{}\n\n// int\ni = 42\n// string\ni = \"hello\"\n// struct\ni = struct{}{}\n// map\ni = map[string]int{\"key\": 1}\n\n// 型アサーション\nstr, ok := i.(string)\nif ok {\n// \"hello\"\n  fmt.Println(str)\n}\n\n// チェックなしの型アサーション (間違った型だと panic する)\n// i が int でなければ panic する\nn := i.(int)\n\n// 安全な型チェックのための型スイッチ\nswitch v := i.(type) {\ncase int:\n  fmt.Println(\"int:\", v)\ncase string:\n  fmt.Println(\"string:\", v)\ncase map[string]int:\n  fmt.Println(\"map:\", v[\"key\"])\ndefault:\n  fmt.Println(\"unknown type\")\n}\n\n// 空インターフェースの一般的な使用法\n// 1. fmt.Println は ...interface{} を取る\nfmt.Println(\"value:\", 42, true)\n\n// 2. 混合型を保持するコンテナ\nmixed := []interface{}{42, \"hello\", true}\n\n// 3. 動的構造を持つ JSON のアンマーシャリング\nvar data interface{}\njson.Unmarshal(jsonBytes, &data)"
+      "title": "Using Interfaces",
+      "code": "// インターフェースの使用\nfunc printShapeInfo(s Shape) {\n  fmt.Printf(\"Area: %f, Perimeter: %f\\n\", \n    s.Area(), s.Perimeter())\n}\n\nrect := Rectangle{5, 10}\n// 暗黙的に Shape を満たす\nprintShapeInfo(rect)\n\ncirc := Circle{5}\n// これも Shape を満たす\nprintShapeInfo(circ)"
+    },
+    {
+      "title": "Interface Value Structure",
+      "code": "// インターフェース値は 2 ワード構造:\n// 1. 型情報へのポインタ (型記述子)\n// 2. 実際のデータへのポインタ (値)"
+    },
+    {
+      "title": "Nil Interface vs Interface with Nil Value",
+      "code": "// nil インターフェース\n// ゼロ値は nil\nvar s Shape\n// true\nfmt.Println(s == nil)\n\n// 具体的な値を持つインターフェース\n// s は型情報と値を含む\ns = Rectangle{5, 10}\n// \"main.Rectangle\"\nfmt.Printf(\"%T\\n\", s)\n\n// nil 値を持つインターフェース (ただし型は定義されている)\nvar p *Rectangle = nil\n// s は型情報を持つが値は nil\ns = p\n// false - インターフェース値は nil ではない\nfmt.Println(s == nil)\n// \"*main.Rectangle\"\nfmt.Printf(\"%T\\n\", s)"
+    },
+    {
+      "title": "Type Assertion",
+      "code": "// 型アサーション\n// Rectangle であれば具体的な値を抽出\nrect, ok := s.(Rectangle)\nif ok {\n  fmt.Println(\"It's a rectangle:\", rect)\n}"
+    },
+    {
+      "title": "Type Switch",
+      "code": "// 型スイッチ\nswitch v := s.(type) {\ncase Rectangle:\n  fmt.Println(\"Rectangle with area:\", v.Area())\ncase Circle:\n  fmt.Println(\"Circle with radius:\", v.Radius)\ncase nil:\n  fmt.Println(\"nil shape\")\ndefault:\n  fmt.Println(\"Unknown shape\")\n}"
+    },
+    {
+      "title": "Empty Interface (interface{} / any)",
+      "code": "// 空インターフェース (interface{} または Go 1.18+ の any) は任意の値を保持できる\n// または: var i any (Go 1.18+)\nvar i interface{}\n\n// int\ni = 42\n// string\ni = \"hello\"\n// struct\ni = struct{}{}\n// map\ni = map[string]int{\"key\": 1}"
+    },
+    {
+      "title": "Empty Interface Type Assertion",
+      "code": "// 型アサーション\nstr, ok := i.(string)\nif ok {\n// \"hello\"\n  fmt.Println(str)\n}\n\n// チェックなしの型アサーション (間違った型だと panic する)\n// i が int でなければ panic する\nn := i.(int)"
+    },
+    {
+      "title": "Empty Interface Type Switch",
+      "code": "// 安全な型チェックのための型スイッチ\nswitch v := i.(type) {\ncase int:\n  fmt.Println(\"int:\", v)\ncase string:\n  fmt.Println(\"string:\", v)\ncase map[string]int:\n  fmt.Println(\"map:\", v[\"key\"])\ndefault:\n  fmt.Println(\"unknown type\")\n}"
+    },
+    {
+      "title": "Empty Interface Common Uses",
+      "code": "// 空インターフェースの一般的な使用法\n// 1. fmt.Println は ...interface{} を取る\nfmt.Println(\"value:\", 42, true)\n\n// 2. 混合型を保持するコンテナ\nmixed := []interface{}{42, \"hello\", true}\n\n// 3. 動的構造を持つ JSON のアンマーシャリング\nvar data interface{}\njson.Unmarshal(jsonBytes, &data)"
     },
     {
       "title": "Interface Composition",
       "code": "// インターフェースは他のインターフェースから構成できる\ntype Reader interface {\n  Read(p []byte) (n int, err error)\n}\n\ntype Writer interface {\n  Write(p []byte) (n int, err error)\n}\n\n// ReadWriter は Reader と Writer を組み合わせる\ntype ReadWriter interface {\n  Reader\n  Writer\n}\n\n// 型が Reader と Writer の両方を実装していれば、ReadWriter を実装する\ntype Buffer struct {\n  // ...\n}\n\nfunc (b *Buffer) Read(p []byte) (n int, err error) {\n  // 実装\n  return len(p), nil\n}\n\nfunc (b *Buffer) Write(p []byte) (n int, err error) {\n  // 実装\n  return len(p), nil\n}\n\n// これで Buffer は ReadWriter として使用できる\nvar rw ReadWriter = &Buffer{}\n\n// 標準ライブラリの例\n// io.ReadCloser, io.WriteCloser, io.ReadWriteCloser"
     },
     {
-      "title": "Interface Best Practices",
-      "code": "// 1. インターフェースを小さく保つ (単一責任)\n// 良い例:\ntype Reader interface {\n  Read(p []byte) (n int, err error)\n}\n\ntype Writer interface {\n  Write(p []byte) (n int, err error)\n}\n\n// 2. インターフェースを受け入れ、具体的な型を返す\n// 良い例:\nfunc processData(r Reader) *Result {\n  // 任意の Reader からデータを処理\n  return &Result{...}\n}\n\n// 3. インターフェースを実装側ではなく、使用する側で定義する\n// 良い例 (クライアントコード内):\ntype UserStore interface {\n  GetUser(id string) (*User, error)\n  SaveUser(user *User) error\n}\n\n// 4. インターフェースの命名規則を使用する\n// 単一メソッドのインターフェースはしばしば -er で終わる\n// 良い例\ntype Reader interface { Read(...) }\n// 良い例\ntype Writer interface { Write(...) }\n\n// 5. 空インターフェースの使いすぎを避ける\n// 悪い例:\nfunc Process(data interface{}) interface{} {...}\n\n// より良い例:\nfunc Process(data UserData) Result {...}\n\n// 6. nil インターフェース値を正しく返す\n// 不正解 (nil でないインターフェースを返す):\nfunc getData() io.Reader {\n  var p *bytes.Buffer = nil\n// nil 値を持つ nil でないインターフェースを返す\n  return p\n}\n\n// 正解:\nfunc getData() io.Reader {\n// nil インターフェースを返す\n  return nil"
+      "title": "Best Practice: Keep Interfaces Small",
+      "code": "// 1. インターフェースを小さく保つ (単一責任)\n// 良い例:\ntype Reader interface {\n  Read(p []byte) (n int, err error)\n}\n\ntype Writer interface {\n  Write(p []byte) (n int, err error)\n}"
     },
     {
-      "title": "Generics and Interfaces (Go 1.18+)",
-      "code": "// 型パラメータ (ジェネリクス) とインターフェース\n\n// 制約インターフェース (許可される型を定義)\ntype Number interface {\n  int | int32 | int64 | float32 | float64\n}\n\n// 制約付きのジェネリック関数\nfunc Sum[T Number](values []T) T {\n  var sum T\n  for _, v := range values {\n    sum += v\n  }\n  return sum\n}\n\n// 使用法\nints := []int{1, 2, 3, 4}\n// 型推論: sum は int\nsum := Sum(ints)\n\nfloats := []float64{1.1, 2.2, 3.3}\n// 型推論: floatSum は float64\nfloatSum := Sum(floats)\n\n// メソッド制約を持つ型パラメータ\ntype Stringer interface {\n  String() string\n}\n\nfunc Join[T Stringer](values []T, sep string) string {\n  result := \"\"\n  for i, v := range values {\n    if i > 0 {\n      result += sep\n    }\n    result += v.String()\n  }\n  return result\n}\n\n// ジェネリックデータ構造\ntype List[T any] struct {\n  data []T\n}\n\nfunc (l *List[T]) Add(item T) {\n  l.data = append(l.data, item)\n}\n\nfunc (l *List[T]) Get(index int) T {\n  return l.data[index]\n}"
+      "title": "Best Practice: Accept Interfaces, Return Structs",
+      "code": "// 2. インターフェースを受け入れ、具体的な型を返す\n// 良い例:\nfunc processData(r Reader) *Result {\n  // 任意の Reader からデータを処理\n  return &Result{...}\n}"
+    },
+    {
+      "title": "Best Practice: Define Interfaces Where Used",
+      "code": "// 3. インターフェースを実装側ではなく、使用する側で定義する\n// 良い例 (クライアントコード内):\ntype UserStore interface {\n  GetUser(id string) (*User, error)\n  SaveUser(user *User) error\n}"
+    },
+    {
+      "title": "Best Practice: Naming Conventions (-er)",
+      "code": "// 4. インターフェースの命名規則を使用する\n// 単一メソッドのインターフェースはしばしば -er で終わる\n// 良い例\ntype Reader interface { Read(...) }\n// 良い例\ntype Writer interface { Write(...) }"
+    },
+    {
+      "title": "Best Practice: Avoid Overusing Empty Interface",
+      "code": "// 5. 空インターフェースの使いすぎを避ける\n// 悪い例:\nfunc Process(data interface{}) interface{} {...}\n\n// より良い例:\nfunc Process(data UserData) Result {...}"
+    },
+    {
+      "title": "Best Practice: Returning Nil Interfaces Correctly",
+      "code": "// 6. nil インターフェース値を正しく返す\n// 不正解 (nil でないインターフェースを返す):\nfunc getData() io.Reader {\n  var p *bytes.Buffer = nil\n// nil 値を持つ nil でないインターフェースを返す\n  return p\n}\n\n// 正解:\nfunc getData() io.Reader {\n// nil インターフェースを返す\n  return nil\n}"
+    },
+    {
+      "title": "Generics: Constraint Interfaces",
+      "code": "// 型パラメータ (ジェネリクス) とインターフェース\n\n// 制約インターフェース (許可される型を定義)\ntype Number interface {\n  int | int32 | int64 | float32 | float64\n}"
+    },
+    {
+      "title": "Generics: Generic Functions with Constraints",
+      "code": "// 制約付きのジェネリック関数\nfunc Sum[T Number](values []T) T {\n  var sum T\n  for _, v := range values {\n    sum += v\n  }\n  return sum\n}\n\n// 使用法\nints := []int{1, 2, 3, 4}\n// 型推論: sum は int\nsum := Sum(ints)\n\nfloats := []float64{1.1, 2.2, 3.3}\n// 型推論: floatSum は float64\nfloatSum := Sum(floats)"
+    },
+    {
+      "title": "Generics: Method Constraints",
+      "code": "// メソッド制約を持つ型パラメータ\ntype Stringer interface {\n  String() string\n}\n\nfunc Join[T Stringer](values []T, sep string) string {\n  result := \"\"\n  for i, v := range values {\n    if i > 0 {\n      result += sep\n    }\n    result += v.String()\n  }\n  return result\n}"
+    },
+    {
+      "title": "Generics: Generic Data Structures",
+      "code": "// ジェネリックデータ構造\ntype List[T any] struct {\n  data []T\n}\n\nfunc (l *List[T]) Add(item T) {\n  l.data = append(l.data, item)\n}\n\nfunc (l *List[T]) Get(index int) T {\n  return l.data[index]\n}"
     }
   ]
 }

--- a/src/data/go-cheatsheet/io-operations.json
+++ b/src/data/go-cheatsheet/io-operations.json
@@ -2,24 +2,108 @@
   "title": "I/O Operations",
   "codeExamples": [
     {
-      "title": "File I/O",
-      "code": "// 基本的なファイル操作\nimport (\n  \"io\"\n  \"os\"\n)\n\n// ファイル全体を読み込む\ndata, err := os.ReadFile(\"filename.txt\")\nif err != nil {\n  // エラー処理\n}\nfmt.Println(string(data))\n\n// ファイルへの書き込み\nerr = os.WriteFile(\"output.txt\", []byte(\"Hello, world!\"), 0644)\nif err != nil {\n  // エラー処理\n}\n\n// より詳細な制御でファイルを開く\n// 読み取り専用\nfile, err := os.Open(\"filename.txt\")\nif err != nil {\n  // エラー処理\n}\ndefer file.Close()\n\n// 書き込み用に開く (作成または切り捨て)\nfile, err = os.Create(\"output.txt\")\nif err != nil {\n  // エラー処理\n}\ndefer file.Close()\n\n// 特定のフラグとパーミッションで開く\nfile, err = os.OpenFile(\"file.txt\", os.O_RDWR|os.O_CREATE, 0644)\nif err != nil {\n  // エラー処理\n}\ndefer file.Close()\n\n// バッファを使用した読み込み\nbuf := make([]byte, 1024)\nn, err := file.Read(buf)\nif err != nil && err != io.EOF {\n  // エラー処理\n}\n// バッファを実際に読み取られたバイト数にリサイズ\nbuf = buf[:n]\n\n// ファイルへの書き込み\nn, err = file.Write([]byte(\"Hello, Go!\"))\nif err != nil {\n  // エラー処理\n}\n\n// ファイル内でのシーク\n// 開始位置からシーク\nnewPos, err := file.Seek(10, io.SeekStart)\nif err != nil {\n  // エラー処理\n}"
+      "title": "Reading Entire File (os.ReadFile)",
+      "code": "// ファイル全体を読み込む\ndata, err := os.ReadFile(\"filename.txt\")\nif err != nil {\n  // エラー処理\n}\nfmt.Println(string(data))"
     },
     {
-      "title": "io/ioutil and io Packages",
-      "code": "// io パッケージの操作\nimport (\n  \"io\"\n// Go 1.16+ で非推奨、関数は io/os に移動\n  \"io/ioutil\"\n)\n\n// reader から writer へデータをコピー\nn, err := io.Copy(dst, src)\nif err != nil {\n  // エラー処理\n}\n\n// バッファサイズ制限付きでコピー\nn, err = io.CopyN(dst, src, 1024)\n\n// 一時ディレクトリを作成 (Go 1.15 以前)\ntempDir, err := ioutil.TempDir(\"\", \"prefix-\")\nif err != nil {\n  // エラー処理\n}\n\n// 一時ディレクトリを作成 (Go 1.16+)\ntempDir, err = os.MkdirTemp(\"\", \"prefix-\")\nif err != nil {\n  // エラー処理\n}\n\n// 一時ファイルを作成 (Go 1.15 以前)\ntempFile, err := ioutil.TempFile(\"\", \"prefix-*.txt\")\nif err != nil {\n  // エラー処理\n}\ndefer tempFile.Close()\n\n// 一時ファイルを作成 (Go 1.16+)\ntempFile, err = os.CreateTemp(\"\", \"prefix-*.txt\")\nif err != nil {\n  // エラー処理\n}\ndefer tempFile.Close()\n\n// reader からすべて読み込む\ndata, err := io.ReadAll(reader)\nif err != nil {\n  // エラー処理\n}\n\n// マルチリーダーを作成 (reader を連結)\nmultiReader := io.MultiReader(reader1, reader2, reader3)\n\n// マルチライターを作成 (複数の writer に同時に書き込む)\nmultiWriter := io.MultiWriter(writer1, writer2, writer3)"
+      "title": "Writing Entire File (os.WriteFile)",
+      "code": "// ファイルへの書き込み\nerr = os.WriteFile(\"output.txt\", []byte(\"Hello, world!\"), 0644)\nif err != nil {\n  // エラー処理\n}"
     },
     {
-      "title": "Buffered I/O",
-      "code": "// パフォーマンスのためのバッファ付き I/O\nimport (\n  \"bufio\"\n  \"os\"\n)\n\n// バッファ付き読み込み\nfile, err := os.Open(\"file.txt\")\nif err != nil {\n  // エラー処理\n}\ndefer file.Close()\n\n// バッファ付きリーダーを作成\nreader := bufio.NewReader(file)\n\n// 1バイト読み込み\nb, err := reader.ReadByte()\nif err != nil {\n  // エラー処理\n}\n\n// 区切り文字まで読み込み\n// 改行まで読み込む\nline, err := reader.ReadString('\\n')\nif err != nil {\n  // エラー処理\n}\n\n// 行ごとの読み込みのための Scanner\nscanner := bufio.NewScanner(file)\nfor scanner.Scan() {\n  line := scanner.Text()\n  // 行を処理\n}\nif err := scanner.Err(); err != nil {\n  // エラー処理\n}\n\n// カスタム分割関数\n// 行ではなく単語でスキャン\nscanner.Split(bufio.ScanWords)\n\n// バッファ付き書き込み\nfile, err = os.Create(\"output.txt\")\nif err != nil {\n  // エラー処理\n}\ndefer file.Close()\n\nwriter := bufio.NewWriter(file)\n\n// 文字列を書き込む\nn, err := writer.WriteString(\"Hello, world!\\n\")\nif err != nil {\n  // エラー処理\n}\n\n// バイトを書き込む\nerr = writer.WriteByte('X')\nif err != nil {\n  // エラー処理\n}\n\n// バッファを基底の writer にフラッシュ\nerr = writer.Flush()\nif err != nil {\n  // エラー処理\n}"
+      "title": "Opening Files (os.Open, os.Create, os.OpenFile)",
+      "code": "// より詳細な制御でファイルを開く\n// 読み取り専用\nfileRead, err := os.Open(\"filename.txt\")\nif err != nil { /* エラー処理 */ }\ndefer fileRead.Close()\n\n// 書き込み用に開く (作成または切り捨て)\nfileWrite, err := os.Create(\"output.txt\")\nif err != nil { /* エラー処理 */ }\ndefer fileWrite.Close()\n\n// 特定のフラグとパーミッションで開く\nfileAppend, err := os.OpenFile(\"file.txt\", os.O_APPEND|os.O_WRONLY, 0644)\nif err != nil { /* エラー処理 */ }\ndefer fileAppend.Close()"
     },
     {
-      "title": "Streaming I/O",
-      "code": "// reader と writer を使用した I/O ストリームの操作\nimport (\n  \"bytes\"\n  \"encoding/csv\"\n  \"encoding/json\"\n  \"io\"\n  \"strings\"\n)\n\n// Reader としての文字列\nstrReader := strings.NewReader(\"Hello, World!\")\n\n// Buffer としてのバイト (Reader および Writer)\nbuffer := bytes.NewBuffer([]byte(\"Hello\"))\n// バッファに追加\nbuffer.WriteString(\", Go!\")\n// バイトを取得\ndata := buffer.Bytes()\n\n// reader の制限\n// 最大 1024 バイト読み込む\nlimitReader := io.LimitReader(reader, 1024)\n\n// reader の連鎖 (例: 解凍してデコード)\ndecompressed := gzip.NewReader(file)\ndefer decompressed.Close()\ndecoder := json.NewDecoder(decompressed)\n\nvar data struct {\n  Name string `json:\"name\"`\n  Age  int    `json:\"age\"`\n}\n\nerr = decoder.Decode(&data)\nif err != nil {\n  // エラー処理\n}\n\n// writer の連鎖 (例: エンコードして圧縮)\ncompressedFile, err := os.Create(\"data.gz\")\nif err != nil {\n  // エラー処理\n}\ndefer compressedFile.Close()\n\ncompressed := gzip.NewWriter(compressedFile)\ndefer compressed.Close()\n\nencoder := json.NewEncoder(compressed)\nerr = encoder.Encode(data)\nif err != nil {\n  // エラー処理\n}\n\n// CSV reader の例\ncsvReader := csv.NewReader(file)\nrecords, err := csvReader.ReadAll()\nif err != nil {\n  // エラー処理\n}\n\n// CSV writer の例\ncsvWriter := csv.NewWriter(file)\nerr = csvWriter.WriteAll(records)\nif err != nil {\n  // エラー処理\n}\ncsvWriter.Flush()"
+      "title": "Reading from File (file.Read)",
+      "code": "// バッファを使用した読み込み\nfile, _ := os.Open(\"filename.txt\")\ndefer file.Close()\nbuf := make([]byte, 1024)\nn, err := file.Read(buf)\nif err != nil && err != io.EOF {\n  // エラー処理\n}\n// バッファを実際に読み取られたバイト数にリサイズ\nreadData := buf[:n]\nfmt.Println(string(readData))"
     },
     {
-      "title": "Directory Operations",
-      "code": "// ディレクトリの操作\nimport (\n  \"os\"\n  \"path/filepath\"\n)\n\n// ディレクトリを作成\nerr := os.Mkdir(\"new-dir\", 0755)\nif err != nil {\n  // エラー処理\n}\n\n// ネストされたディレクトリを作成\nerr = os.MkdirAll(\"path/to/nested/dir\", 0755)\nif err != nil {\n  // エラー処理\n}\n\n// 現在のディレクトリを取得\ncurrentDir, err := os.Getwd()\nif err != nil {\n  // エラー処理\n}\n\n// ディレクトリを変更\nerr = os.Chdir(\"new-dir\")\nif err != nil {\n  // エラー処理\n}\n\n// ディレクトリエントリを読み込む (Go <1.16)\ndir, err := os.Open(\"dir\")\nif err != nil {\n  // エラー処理\n}\ndefer dir.Close()\n\n// すべてのエントリを読み込む\nentries, err := dir.Readdir(-1)\nif err != nil {\n  // エラー処理\n}\n\nfor _, entry := range entries {\n  fmt.Println(entry.Name(), entry.IsDir())\n}\n\n// ディレクトリエントリを読み込む (Go 1.16+)\nentries, err = os.ReadDir(\"dir\")\nif err != nil {\n  // エラー処理\n}\n\nfor _, entry := range entries {\n  info, err := entry.Info()\n  if err != nil {\n    // エラー処理\n  }\n  fmt.Println(entry.Name(), entry.IsDir(), info.Size())\n}\n\n// ディレクトリツリーを走査\nerr = filepath.Walk(\"root-dir\", func(path string, info os.FileInfo, err error) error {\n  if err != nil {\n// パスへのアクセスエラー\n    return err\n  }\n  fmt.Println(path, info.Size())\n  return nil\n})\nif err != nil {\n  // エラー処理\n}\n\n// WalkDir はより効率的 (Go 1.16+)\nerr = filepath.WalkDir(\"root-dir\", func(path string, d fs.DirEntry, err error) error {\n  if err != nil {\n    return err\n  }\n  fmt.Println(path, d.IsDir())\n  return nil\n})"
+      "title": "Writing to File (file.Write)",
+      "code": "// ファイルへの書き込み\nfile, _ := os.Create(\"output.txt\")\ndefer file.Close()\nn, err := file.Write([]byte(\"Hello, Go!\"))\nif err != nil {\n  // エラー処理\n}"
+    },
+    {
+      "title": "Seeking in File (file.Seek)",
+      "code": "// ファイル内でのシーク\nfile, _ := os.Open(\"filename.txt\")\ndefer file.Close()\n// 開始位置から10バイト目にシーク\nnewPos, err := file.Seek(10, io.SeekStart)\nif err != nil {\n  // エラー処理\n}\n// 現在位置から5バイト戻る\nnewPos, err = file.Seek(-5, io.SeekCurrent)\n// 末尾から20バイト前にシーク\nnewPos, err = file.Seek(-20, io.SeekEnd)"
+    },
+    {
+      "title": "Copying Data (io.Copy, io.CopyN)",
+      "code": "// reader から writer へデータをコピー\nnBytes, err := io.Copy(dstWriter, srcReader)\nif err != nil { /* エラー処理 */ }\n\n// バッファサイズ制限付きでコピー\nnBytesLimited, err := io.CopyN(dstWriter, srcReader, 1024)\nif err != nil && err != io.EOF { /* エラー処理 */ }"
+    },
+    {
+      "title": "Temporary Directories (os.MkdirTemp)",
+      "code": "// 一時ディレクトリを作成 (Go 1.16+)\ntempDir, err := os.MkdirTemp(\"\", \"my-app-*\") // * はランダムな文字列に置換される\nif err != nil { /* エラー処理 */ }\ndefer os.RemoveAll(tempDir) // クリーンアップ\nfmt.Println(\"Temp dir:\", tempDir)"
+    },
+    {
+      "title": "Temporary Files (os.CreateTemp)",
+      "code": "// 一時ファイルを作成 (Go 1.16+)\ntempFile, err := os.CreateTemp(\"\", \"my-app-*.tmp\")\nif err != nil { /* エラー処理 */ }\ndefer os.Remove(tempFile.Name()) // クリーンアップ\ndefer tempFile.Close()\nfmt.Println(\"Temp file:\", tempFile.Name())"
+    },
+    {
+      "title": "Reading All from Reader (io.ReadAll)",
+      "code": "// reader からすべて読み込む\nreader := strings.NewReader(\"some data\")\ndata, err := io.ReadAll(reader)\nif err != nil { /* エラー処理 */ }\nfmt.Println(string(data))"
+    },
+    {
+      "title": "MultiReader (io.MultiReader)",
+      "code": "// マルチリーダーを作成 (reader を連結)\nr1 := strings.NewReader(\"first \")\nr2 := strings.NewReader(\"second\")\nmultiReader := io.MultiReader(r1, r2)\ndata, _ := io.ReadAll(multiReader)\nfmt.Println(string(data)) // \"first second\""
+    },
+    {
+      "title": "MultiWriter (io.MultiWriter)",
+      "code": "// マルチライターを作成 (複数の writer に同時に書き込む)\nvar buf1, buf2 bytes.Buffer\nmultiWriter := io.MultiWriter(&buf1, &buf2)\nmultiWriter.Write([]byte(\"data\"))\nfmt.Println(buf1.String()) // \"data\"\nfmt.Println(buf2.String()) // \"data\""
+    },
+    {
+      "title": "Buffered Reader (bufio.NewReader)",
+      "code": "// バッファ付き読み込み\nfile, _ := os.Open(\"file.txt\")\ndefer file.Close()\nreader := bufio.NewReader(file)\n\n// 1バイト読み込み\nb, err := reader.ReadByte()\n\n// 区切り文字まで読み込み (例: 改行)\nline, err := reader.ReadString('\\n')"
+    },
+    {
+      "title": "Buffered Scanner (bufio.NewScanner)",
+      "code": "// 行ごとの読み込みのための Scanner\nfile, _ := os.Open(\"file.txt\")\ndefer file.Close()\nscanner := bufio.NewScanner(file)\nfor scanner.Scan() {\n  line := scanner.Text()\n  fmt.Println(line)\n}\nif err := scanner.Err(); err != nil {\n  // エラー処理\n}\n\n// カスタム分割関数 (例: 単語ごと)\nscanner.Split(bufio.ScanWords)"
+    },
+    {
+      "title": "Buffered Writer (bufio.NewWriter)",
+      "code": "// バッファ付き書き込み\nfile, _ := os.Create(\"output.txt\")\ndefer file.Close()\nwriter := bufio.NewWriter(file)\n\n// 文字列を書き込む\nn, err := writer.WriteString(\"Hello, world!\\n\")\n\n// バイトを書き込む\nerr = writer.WriteByte('X')\n\n// バッファを基底の writer にフラッシュ (重要!)\nerr = writer.Flush()\nif err != nil {\n  // エラー処理\n}"
+    },
+    {
+      "title": "String as Reader (strings.NewReader)",
+      "code": "// Reader としての文字列\nstrReader := strings.NewReader(\"This is a string reader.\")\ndata, _ := io.ReadAll(strReader)\nfmt.Println(string(data))"
+    },
+    {
+      "title": "Bytes Buffer (bytes.NewBuffer)",
+      "code": "// Buffer としてのバイト (Reader および Writer)\nbuffer := bytes.NewBuffer([]byte(\"Initial data\"))\n// バッファに追加\nbuffer.WriteString(\", more data\")\n// バイトを取得\ndata := buffer.Bytes()\nfmt.Println(string(data)) // \"Initial data, more data\"\n// バッファから読み込む\nreadData := make([]byte, 5)\nbuffer.Read(readData)\nfmt.Println(string(readData)) // \"Initi\""
+    },
+    {
+      "title": "Limited Reader (io.LimitReader)",
+      "code": "// reader の制限\nreader := strings.NewReader(\"1234567890abcdef\")\n// 最大 10 バイト読み込む\nlimitReader := io.LimitReader(reader, 10)\ndata, _ := io.ReadAll(limitReader)\nfmt.Println(string(data)) // \"1234567890\""
+    },
+    {
+      "title": "Chaining Readers (e.g., Decompress + Decode)",
+      "code": "// reader の連鎖 (例: 解凍してデコード)\n// compressedData は io.Reader (例: os.File, bytes.Buffer)\n// var compressedData io.Reader\n// decompressed, _ := gzip.NewReader(compressedData)\n// defer decompressed.Close()\n// decoder := json.NewDecoder(decompressed)\n// var targetData MyStruct\n// err := decoder.Decode(&targetData)"
+    },
+    {
+      "title": "Chaining Writers (e.g., Encode + Compress)",
+      "code": "// writer の連鎖 (例: エンコードして圧縮)\n// targetWriter は io.Writer (例: os.File, bytes.Buffer)\n// var targetWriter io.Writer\n// compressed := gzip.NewWriter(targetWriter)\n// defer compressed.Close()\n// encoder := json.NewEncoder(compressed)\n// err := encoder.Encode(sourceData)\n// compressed.Flush() // gzip writer のフラッシュも忘れずに"
+    },
+    {
+      "title": "CSV Reader (encoding/csv)",
+      "code": "// CSV reader の例\ncsvString := `\"Header 1\",\"Header 2\"\n\"Value 1\",\"Value 2\"\n`\ncsvReader := csv.NewReader(strings.NewReader(csvString))\nrecords, err := csvReader.ReadAll()\nif err != nil { /* エラー処理 */ }\nfmt.Println(records) // [[Header 1 Header 2] [Value 1 Value 2]]"
+    },
+    {
+      "title": "CSV Writer (encoding/csv)",
+      "code": "// CSV writer の例\nvar buf bytes.Buffer\ncsvWriter := csv.NewWriter(&buf)\nrecords := [][]string{\n    {\"Header 1\", \"Header 2\"},\n    {\"Value 1\", \"Value 2\"},\n}\nerr := csvWriter.WriteAll(records)\nif err != nil { /* エラー処理 */ }\ncsvWriter.Flush() // バッファをフラッシュ\nfmt.Println(buf.String())"
+    },
+    {
+      "title": "Creating Directories (os.Mkdir, os.MkdirAll)",
+      "code": "// ディレクトリを作成\nerr := os.Mkdir(\"my-single-dir\", 0755)\nif err != nil && !os.IsExist(err) { /* エラー処理 */ }\n\n// ネストされたディレクトリを作成 (親が存在しなくてもOK)\nerr = os.MkdirAll(\"path/to/my/nested/dir\", 0755)\nif err != nil { /* エラー処理 */ }"
+    },
+    {
+      "title": "Working Directory (os.Getwd, os.Chdir)",
+      "code": "// 現在のディレクトリを取得\ncurrentDir, err := os.Getwd()\nif err != nil { /* エラー処理 */ }\nfmt.Println(\"Current dir:\", currentDir)\n\n// ディレクトリを変更\nerr = os.Chdir(\"path/to/my\") // 存在すると仮定\nif err != nil { /* エラー処理 */ }\nnewDir, _ := os.Getwd()\nfmt.Println(\"New dir:\", newDir)"
+    },
+    {
+      "title": "Reading Directory Entries (os.ReadDir, Go 1.16+)",
+      "code": "// ディレクトリエントリを読み込む (Go 1.16+)\nentries, err := os.ReadDir(\".\") // 現在のディレクトリ\nif err != nil { /* エラー処理 */ }\n\nfor _, entry := range entries {\n  fmt.Printf(\"Name: %s, IsDir: %v\\n\", entry.Name(), entry.IsDir())\n  // 詳細情報が必要な場合\n  // info, err := entry.Info()\n  // if err == nil {\n  //   fmt.Println(\" Size:\", info.Size())\n  // }\n}"
+    },
+    {
+      "title": "Walking Directory Tree (filepath.WalkDir, Go 1.16+)",
+      "code": "// WalkDir はより効率的 (Go 1.16+)\nerr := filepath.WalkDir(\".\", func(path string, d fs.DirEntry, err error) error {\n  if err != nil {\n    fmt.Printf(\"Error accessing path %q: %v\\n\", path, err)\n    return err // エラーが発生したパスの処理を停止\n  }\n  if !d.IsDir() {\n    fmt.Println(\"File:\", path)\n  }\n  return nil // 次のエントリへ進む\n})\nif err != nil {\n  fmt.Println(\"WalkDir error:\", err)\n}"
     }
   ]
 }

--- a/src/data/go-cheatsheet/methods.json
+++ b/src/data/go-cheatsheet/methods.json
@@ -2,24 +2,56 @@
   "title": "Methods",
   "codeExamples": [
     {
-      "title": "Methods",
-      "code": "// 型を定義\ntype Rectangle struct {\n  Width, Height float64\n}\n\n// 値レシーバを持つメソッド\nfunc (r Rectangle) Area() float64 {\n  return r.Width * r.Height\n}\n\n// 変更のためのポインタレシーバ\nfunc (r *Rectangle) Scale(factor float64) {\n  r.Width *= factor\n  r.Height *= factor\n}\n\n// メソッドの使用\nrect := Rectangle{10, 5}\n// 50\narea := rect.Area()\n// Width=20, Height=10\nrect.Scale(2)\n\n// 構造体以外の型に対するメソッド\ntype MyInt int\n\nfunc (m MyInt) IsEven() bool {\n  return m%2 == 0\n}\n\nfunc (m *MyInt) Add(n MyInt) {\n  *m += n\n}\n\nvar num MyInt = 10\n// true\nfmt.Println(num.IsEven())\nnum.Add(5)\n// 15\nfmt.Println(num)"
+      "title": "Method Definition (Struct)",
+      "code": "// 型を定義\ntype Rectangle struct {\n  Width, Height float64\n}\n\n// 値レシーバを持つメソッド\nfunc (r Rectangle) Area() float64 {\n  return r.Width * r.Height\n}\n\n// 変更のためのポインタレシーバ\nfunc (r *Rectangle) Scale(factor float64) {\n  r.Width *= factor\n  r.Height *= factor\n}\n\n// メソッドの使用\nrect := Rectangle{10, 5}\n// 50\narea := rect.Area()\n// Width=20, Height=10\nrect.Scale(2)"
     },
     {
-      "title": "Value vs Pointer Receivers",
-      "code": "// 値レシーバ (コピー、不変操作)\nfunc (r Rectangle) Double() Rectangle {\n  return Rectangle{\n    Width:  r.Width * 2,\n    Height: r.Height * 2,\n  }\n}\n\n// ポインタレシーバ (元を変更)\nfunc (r *Rectangle) Resize(w, h float64) {\n  r.Width = w\n  r.Height = h\n}\n\n// 使用法\nrect := Rectangle{5, 10}\n// 新しい長方形\nrect2 := rect.Double()\n// 元を変更\nrect.Resize(20, 30)\n\n// 値レシーバを使用する場合:\n// - メソッドがレシーバを変更しない\n// - レシーバが小さな値 (int, float64 など)\n// - レシーバが慣例的に不変である\n// - \"nil\" レシーバの処理が不要である\n\n// ポインタレシーバを使用する場合:\n// - メソッドがレシーバを変更する\n// - レシーバが大きい (コピーを避けるため)\n// - 型の他のメソッドとの一貫性\n// - レシーバが nil である可能性がある\n\n// Go は自動的に変換を処理する:\nrect := Rectangle{5, 10}\n// 値に対してメソッドを呼び出す\narea := rect.Area()\n\nprect := &Rectangle{5, 10}\n// Go は値メソッドを呼び出すためにポインタを自動的に逆参照する\narea = prect.Area()\n\n// しかし、ポインタレシーバを必要とするメソッドはアドレス可能な値に対してのみ機能する\n// Go は自動的に rect へのポインタを取得する\nrect.Resize(20, 30)\n// エラー: 一時的な値のアドレスを取得できない\nRectangle{5, 10}.Resize(20, 30)"
+      "title": "Method Definition (Non-Struct)",
+      "code": "// 構造体以外の型に対するメソッド\ntype MyInt int\n\nfunc (m MyInt) IsEven() bool {\n  return m%2 == 0\n}\n\nfunc (m *MyInt) Add(n MyInt) {\n  *m += n\n}\n\nvar num MyInt = 10\n// true\nfmt.Println(num.IsEven())\nnum.Add(5)\n// 15\nfmt.Println(num)"
+    },
+    {
+      "title": "Value Receivers",
+      "code": "// 値レシーバ (コピー、不変操作)\nfunc (r Rectangle) Double() Rectangle {\n  return Rectangle{\n    Width:  r.Width * 2,\n    Height: r.Height * 2,\n  }\n}\n\n// 値レシーバを使用する場合:\n// - メソッドがレシーバを変更しない\n// - レシーバが小さな値 (int, float64 など)\n// - レシーバが慣例的に不変である\n// - \"nil\" レシーバの処理が不要である"
+    },
+    {
+      "title": "Pointer Receivers",
+      "code": "// ポインタレシーバ (元を変更)\nfunc (r *Rectangle) Resize(w, h float64) {\n  r.Width = w\n  r.Height = h\n}\n\n// ポインタレシーバを使用する場合:\n// - メソッドがレシーバを変更する\n// - レシーバが大きい (コピーを避けるため)\n// - 型の他のメソッドとの一貫性\n// - レシーバが nil である可能性がある"
+    },
+    {
+      "title": "Receiver Type Conversion (Automatic)",
+      "code": "// Go は自動的に変換を処理する:\nrect := Rectangle{5, 10}\n// 値に対してメソッドを呼び出す\narea := rect.Area()\n\nprect := &Rectangle{5, 10}\n// Go は値メソッドを呼び出すためにポインタを自動的に逆参照する\narea = prect.Area()\n\n// しかし、ポインタレシーバを必要とするメソッドはアドレス可能な値に対してのみ機能する\n// Go は自動的に rect へのポインタを取得する\nrect.Resize(20, 30)\n// エラー: 一時的な値のアドレスを取得できない\n// Rectangle{5, 10}.Resize(20, 30)"
     },
     {
       "title": "Method Expression",
-      "code": "// メソッド式はメソッドを通常の関数に変換する\ntype Point struct{ X, Y float64 }\n\nfunc (p Point) Distance(q Point) float64 {\n  return math.Hypot(q.X-p.X, q.Y-p.Y)\n}\n\n// メソッド式 - 最初のパラメータとして明示的なレシーバ\n// func(Point, Point) float64\ndistance := Point.Distance\np := Point{1, 2}\nq := Point{4, 6}\n// p.Distance(q) と同じ\nfmt.Println(distance(p, q))\n\n// ポインタレシーバのメソッド式\ntype Counter int\n\nfunc (c *Counter) Increment() { *c++ }\n\n// func(*Counter)\nincrement := (*Counter).Increment\nc := Counter(0)\n// (&c).Increment() と同じ\nincrement(&c)\n\n// メソッド値 (レシーバがバインドされる)\np := Point{1, 2}\n// func(Point) float64\ndistanceFromP := p.Distance\n// p.Distance(Point{4, 6}) と同じ\nfmt.Println(distanceFromP(Point{4, 6}))"
+      "code": "// メソッド式はメソッドを通常の関数に変換する\ntype Point struct{ X, Y float64 }\n\nfunc (p Point) Distance(q Point) float64 {\n  return math.Hypot(q.X-p.X, q.Y-p.Y)\n}\n\n// メソッド式 - 最初のパラメータとして明示的なレシーバ\n// func(Point, Point) float64\ndistance := Point.Distance\np := Point{1, 2}\nq := Point{4, 6}\n// p.Distance(q) と同じ\nfmt.Println(distance(p, q))"
     },
     {
-      "title": "Method Chaining",
-      "code": "// 流暢なインターフェースのためのメソッドチェーン\ntype Builder struct {\n  str string\n}\n\n// 各メソッドはチェーンのためにレシーバを返す\nfunc (b *Builder) Add(s string) *Builder {\n  b.str += s\n  return b\n}\n\nfunc (b *Builder) AddSpace() *Builder {\n  b.str += \" \"\n  return b\n}\n\nfunc (b *Builder) ToString() string {\n  return b.str\n}\n\n// 使用法\nb := &Builder{}\nresult := b.Add(\"Hello\").AddSpace().Add(\"World\").ToString()\n// \"Hello World\"\nfmt.Println(result)\n\n// メソッドを使用したビルダーパターン\ntype RequestBuilder struct {\n  method  string\n  url     string\n  headers map[string]string\n}\n\nfunc NewRequestBuilder() *RequestBuilder {\n  return &RequestBuilder{\n    headers: make(map[string]string),\n  }\n}\n\nfunc (rb *RequestBuilder) Method(method string) *RequestBuilder {\n  rb.method = method\n  return rb\n}\n\nfunc (rb *RequestBuilder) URL(url string) *RequestBuilder {\n  rb.url = url\n  return rb\n}\n\nfunc (rb *RequestBuilder) Header(key, value string) *RequestBuilder {\n  rb.headers[key] = value\n  return rb\n}\n\nfunc (rb *RequestBuilder) Build() (*http.Request, error) {\n  req, err := http.NewRequest(rb.method, rb.url, nil)\n  if err != nil {\n    return nil, err\n  }\n  \n  for k, v := range rb.headers {\n    req.Header.Add(k, v)\n  }\n  \n  return req, nil\n}\n\n// 使用法\nreq, err := NewRequestBuilder().\n  Method(\"GET\").\n//example.com\").\n  URL(\"https:\n  Header(\"User-Agent\", \"MyClient/1.0\").\n  Build()"
+      "title": "Method Expression (Pointer Receiver)",
+      "code": "// ポインタレシーバのメソッド式\ntype Counter int\n\nfunc (c *Counter) Increment() { *c++ }\n\n// func(*Counter)\nincrement := (*Counter).Increment\nc := Counter(0)\n// (&c).Increment() と同じ\nincrement(&c)"
     },
     {
-      "title": "Methods vs Functions",
-      "code": "// メソッドは特定の型にバインドされた関数\n\n// 関数アプローチ\nfunc AreaOf(r Rectangle) float64 {\n  return r.Width * r.Height\n}\n\n// メソッドアプローチ\nfunc (r Rectangle) Area() float64 {\n  return r.Width * r.Height\n}\n\n// 使用法の比較\nr := Rectangle{5, 10}\n// パラメータ付きの関数呼び出し\na1 := AreaOf(r)\n// インスタンスに対するメソッド呼び出し\na2 := r.Area()\n\n// メソッドの利点:\n// 1. 名前空間管理 - r.Area() vs AreaOf(r)\n// 2. パッケージ内の任意の型 (構造体だけでなく) にメソッドを定義できる\n// 3. インターフェースを実装できる\n\n// メソッドテーブル - メソッドは型ごとにグループ化される\n// type Rectangle\n//   - Area\n//   - Perimeter\n//   - Scale\n\n// メソッド型\n// 値に対するメソッド - func (v  Type) Method()\n// ポインタに対するメソッド - func (p *Type) Method()\n\n// メソッドセット\n// 型 T の値は、レシーバ型 T で宣言されたメソッドを持つ\n// T へのポインタは、*T で宣言されたメソッドと T のメソッドを持つ"
+      "title": "Method Value",
+      "code": "// メソッド値 (レシーバがバインドされる)\np := Point{1, 2}\n// func(Point) float64\ndistanceFromP := p.Distance\n// p.Distance(Point{4, 6}) と同じ\nfmt.Println(distanceFromP(Point{4, 6}))"
+    },
+    {
+      "title": "Basic Method Chaining",
+      "code": "// 流暢なインターフェースのためのメソッドチェーン\ntype Builder struct {\n  str string\n}\n\n// 各メソッドはチェーンのためにレシーバを返す\nfunc (b *Builder) Add(s string) *Builder {\n  b.str += s\n  return b\n}\n\nfunc (b *Builder) AddSpace() *Builder {\n  b.str += \" \"\n  return b\n}\n\nfunc (b *Builder) ToString() string {\n  return b.str\n}\n\n// 使用法\nb := &Builder{}\nresult := b.Add(\"Hello\").AddSpace().Add(\"World\").ToString()\n// \"Hello World\"\nfmt.Println(result)"
+    },
+    {
+      "title": "Method Chaining (Builder Pattern)",
+      "code": "// メソッドを使用したビルダーパターン\ntype RequestBuilder struct {\n  method  string\n  url     string\n  headers map[string]string\n}\n\nfunc NewRequestBuilder() *RequestBuilder {\n  return &RequestBuilder{\n    headers: make(map[string]string),\n  }\n}\n\nfunc (rb *RequestBuilder) Method(method string) *RequestBuilder {\n  rb.method = method\n  return rb\n}\n\nfunc (rb *RequestBuilder) URL(url string) *RequestBuilder {\n  rb.url = url\n  return rb\n}\n\nfunc (rb *RequestBuilder) Header(key, value string) *RequestBuilder {\n  rb.headers[key] = value\n  return rb\n}\n\nfunc (rb *RequestBuilder) Build() (*http.Request, error) {\n  req, err := http.NewRequest(rb.method, rb.url, nil)\n  if err != nil {\n    return nil, err\n  }\n  \n  for k, v := range rb.headers {\n    req.Header.Add(k, v)\n  }\n  \n  return req, nil\n}\n\n// 使用法\nreq, err := NewRequestBuilder().\n  Method(\"GET\").\n//example.com\").\n  URL(\"https:\n  Header(\"User-Agent\", \"MyClient/1.0\").\n  Build()"
+    },
+    {
+      "title": "Methods vs Functions Comparison",
+      "code": "// メソッドは特定の型にバインドされた関数\n\n// 関数アプローチ\nfunc AreaOf(r Rectangle) float64 {\n  return r.Width * r.Height\n}\n\n// メソッドアプローチ\nfunc (r Rectangle) Area() float64 {\n  return r.Width * r.Height\n}\n\n// 使用法の比較\nr := Rectangle{5, 10}\n// パラメータ付きの関数呼び出し\na1 := AreaOf(r)\n// インスタンスに対するメソッド呼び出し\na2 := r.Area()"
+    },
+    {
+      "title": "Advantages of Methods",
+      "code": "// メソッドの利点:\n// 1. 名前空間管理 - r.Area() vs AreaOf(r)\n// 2. パッケージ内の任意の型 (構造体だけでなく) にメソッドを定義できる\n// 3. インターフェースを実装できる"
+    },
+    {
+      "title": "Method Set",
+      "code": "// メソッドテーブル - メソッドは型ごとにグループ化される\n// type Rectangle\n//   - Area\n//   - Perimeter\n//   - Scale\n\n// メソッド型\n// 値に対するメソッド - func (v  Type) Method()\n// ポインタに対するメソッド - func (p *Type) Method()\n\n// メソッドセット\n// 型 T の値は、レシーバ型 T で宣言されたメソッドを持つ\n// T へのポインタは、*T で宣言されたメソッドと T のメソッドを持つ"
     }
   ]
 }

--- a/src/data/go-cheatsheet/packages.json
+++ b/src/data/go-cheatsheet/packages.json
@@ -2,24 +2,88 @@
   "title": "Packages",
   "codeExamples": [
     {
-      "title": "Package",
-      "code": "// ファイル: math.go\npackage math\n\n// エクスポートされた関数 (大文字で始まる)\nfunc Add(a, b int) int {\n  return a + b\n}\n\n// エクスポートされない関数 (小文字で始まる)\nfunc multiply(a, b int) int {\n  return a * b\n}\n\n// パッケージドキュメント\n// package 宣言の前のこのコメントは\n// godoc でパッケージドキュメントになる\n\n// Package math は基本的な数学的操作を提供する。\npackage math"
+      "title": "Package Declaration",
+      "code": "// ファイル: math.go\npackage math"
     },
     {
-      "title": "Import",
-      "code": "// 単一インポート\nimport \"fmt\"\n\n// 複数インポート\nimport (\n  \"fmt\"\n  \"math\"\n  \"strings\"\n)\n\n// エイリアス付きインポート\nimport (\n// f.Println()\n  f \"fmt\"\n// m.Pi\n  m \"math\"\n// Pi (直接アクセス、本番コードでは避ける)\n  . \"math\"\n// PNG デコーダを登録するが、直接は使用しない\n  _ \"image/png\"\n)\n\n// ドットインポート (非推奨)\nimport . \"math\"\n// パッケージ名なしで直接アクセス\nfmt.Println(Pi)\n\n// ブランクインポート (副作用のためだけに使用)\n// プロファイリングハンドラを登録\nimport _ \"net/http/pprof\"\n\n// 相対インポート (go modules 内)\nimport (\n// 標準インポート\n  \"example.com/project/pkg/util\"\n// modules では無効\n  \"./mylocal\"\n)"
+      "title": "Exported vs Unexported",
+      "code": "// エクスポートされた関数 (大文字で始まる)\nfunc Add(a, b int) int {\n  return a + b\n}\n\n// エクスポートされない関数 (小文字で始まる)\nfunc multiply(a, b int) int {\n  return a * b\n}"
     },
     {
-      "title": "Package initialization",
-      "code": "package mypackage\n\n// パッケージ変数\nvar PackageVar int\n\n// init 関数はパッケージがインポートされるときに実行される\n// main() が開始する前に\nfunc init() {\n  PackageVar = 42\n  // 初期化コード\n}\n\n// 複数の init 関数は宣言順に実行される\nfunc init() {\n  // 最初の init\n}\n\nfunc init() {\n  // 2番目の init\n}\n\nfunc DoSomething() {\n  // 関数コード\n}\n\n// パッケージ初期化順序:\n// 1. パッケージレベルの変数初期化\n// 2. 宣言順の init() 関数\n\n// パッケージ間:\n// 1. インポートされたパッケージが最初に初期化される\n// 2. 次にインポート元のパッケージが初期化される"
+      "title": "Package Documentation",
+      "code": "// パッケージドキュメント\n// package 宣言の前のこのコメントは\n// godoc でパッケージドキュメントになる\n\n// Package math は基本的な数学的操作を提供する。\npackage math"
     },
     {
-      "title": "Go Modules",
-      "code": "// モジュール初期化\n// 新しいモジュールを作成\ngo mod init example.com/mymodule\n\n// モジュールファイル (go.mod)\nmodule example.com/mymodule\n\n// 最小 Go バージョン\ngo 1.19\n\nrequire (\n  github.com/pkg/errors v0.9.1\n  golang.org/x/text v0.9.0\n)\n\nexclude github.com/unwanted/package v1.0.0\n\nreplace github.com/original/package => github.com/fork/package v1.2.0\n\n// 依存関係の管理\n// 依存関係を追加\ngo get github.com/pkg/errors\n// 特定のバージョン\ngo get github.com/pkg/errors@v0.9.1\n// すべての依存関係を更新\ngo get -u\n// 未使用の依存関係をクリーンアップ\ngo mod tidy\n// vendor ディレクトリを作成\ngo mod vendor\n// 依存関係を説明\ngo mod why github.com/pkg/errors\n// すべての依存関係をリスト\ngo list -m all"
+      "title": "Single and Multiple Imports",
+      "code": "// 単一インポート\nimport \"fmt\"\n\n// 複数インポート\nimport (\n  \"fmt\"\n  \"math\"\n  \"strings\"\n)"
     },
     {
-      "title": "Standard Library Packages",
-      "code": "// 主要な標準ライブラリパッケージ\n\n// フォーマット\nimport \"fmt\"\nfmt.Println(\"Hello, world\")\nfmt.Printf(\"%d %s\\n\", 42, \"text\")\n\n// 入出力\nimport \"io\"\nimport \"os\"\nfile, err := os.Open(\"file.txt\")\ndata, err := io.ReadAll(file)\n\n// 文字列\nimport \"strings\"\ns := strings.ToUpper(\"hello\")\ncontains := strings.Contains(s, \"EL\")\nparts := strings.Split(\"a,b,c\", \",\")\n\n// 時間\nimport \"time\"\nnow := time.Now()\ntime.Sleep(time.Second * 2)\nduration := time.Since(now)\n\n// JSON\nimport \"encoding/json\"\ntype Person struct {\n  Name string `json:\"name\"`\n  Age  int    `json:\"age\"`\n}\ndata, err := json.Marshal(person)\nperson := Person{}\nerr := json.Unmarshal(data, &person)\n\n// HTTP\nimport \"net/http\"\nhttp.HandleFunc(\"/hello\", func(w http.ResponseWriter, r *http.Request) {\n  fmt.Fprintf(w, \"Hello\")\n})\nhttp.ListenAndServe(\":8080\", nil)"
+      "title": "Aliased Imports",
+      "code": "// エイリアス付きインポート\nimport (\n// f.Println()\n  f \"fmt\"\n// m.Pi\n  m \"math\"\n)"
+    },
+    {
+      "title": "Dot Imports (Avoid)",
+      "code": "// ドットインポート (非推奨)\nimport . \"math\"\n// パッケージ名なしで直接アクセス\nfmt.Println(Pi)"
+    },
+    {
+      "title": "Blank Imports (Side Effects)",
+      "code": "// ブランクインポート (副作用のためだけに使用)\n// PNG デコーダを登録するが、直接は使用しない\nimport _ \"image/png\"\n// プロファイリングハンドラを登録\nimport _ \"net/http/pprof\""
+    },
+    {
+      "title": "Relative Imports (Go Modules)",
+      "code": "// 相対インポート (go modules 内)\nimport (\n// 標準インポート\n  \"example.com/project/pkg/util\"\n// modules では無効\n//  \"./mylocal\"\n)"
+    },
+    {
+      "title": "Package Variables",
+      "code": "package mypackage\n\n// パッケージ変数\nvar PackageVar int"
+    },
+    {
+      "title": "init() Function",
+      "code": "// init 関数はパッケージがインポートされるときに実行される\n// main() が開始する前に\nfunc init() {\n  PackageVar = 42\n  // 初期化コード\n}"
+    },
+    {
+      "title": "Multiple init() Functions",
+      "code": "// 複数の init 関数は宣言順に実行される\nfunc init() {\n  // 最初の init\n}\n\nfunc init() {\n  // 2番目の init\n}"
+    },
+    {
+      "title": "Package Initialization Order",
+      "code": "// パッケージ初期化順序:\n// 1. パッケージレベルの変数初期化\n// 2. 宣言順の init() 関数\n\n// パッケージ間:\n// 1. インポートされたパッケージが最初に初期化される\n// 2. 次にインポート元のパッケージが初期化される"
+    },
+    {
+      "title": "Go Modules: Initialization (go mod init)",
+      "code": "// モジュール初期化\n// 新しいモジュールを作成\ngo mod init example.com/mymodule"
+    },
+    {
+      "title": "Go Modules: go.mod File",
+      "code": "// モジュールファイル (go.mod)\nmodule example.com/mymodule\n\n// 最小 Go バージョン\ngo 1.19\n\nrequire (\n  github.com/pkg/errors v0.9.1\n  golang.org/x/text v0.9.0\n)\n\nexclude github.com/unwanted/package v1.0.0\n\nreplace github.com/original/package => github.com/fork/package v1.2.0"
+    },
+    {
+      "title": "Go Modules: Dependency Management",
+      "code": "// 依存関係の管理\n// 依存関係を追加\ngo get github.com/pkg/errors\n// 特定のバージョン\ngo get github.com/pkg/errors@v0.9.1\n// すべての依存関係を更新\ngo get -u\n// 未使用の依存関係をクリーンアップ\ngo mod tidy\n// vendor ディレクトリを作成\ngo mod vendor\n// 依存関係を説明\ngo mod why github.com/pkg/errors\n// すべての依存関係をリスト\ngo list -m all"
+    },
+    {
+      "title": "Standard Library: fmt",
+      "code": "// フォーマット\nimport \"fmt\"\nfmt.Println(\"Hello, world\")\nfmt.Printf(\"%d %s\\n\", 42, \"text\")"
+    },
+    {
+      "title": "Standard Library: io / os",
+      "code": "// 入出力\nimport \"io\"\nimport \"os\"\nfile, err := os.Open(\"file.txt\")\ndata, err := io.ReadAll(file)"
+    },
+    {
+      "title": "Standard Library: strings",
+      "code": "// 文字列\nimport \"strings\"\ns := strings.ToUpper(\"hello\")\ncontains := strings.Contains(s, \"EL\")\nparts := strings.Split(\"a,b,c\", \",\")"
+    },
+    {
+      "title": "Standard Library: time",
+      "code": "// 時間\nimport \"time\"\nnow := time.Now()\ntime.Sleep(time.Second * 2)\nduration := time.Since(now)"
+    },
+    {
+      "title": "Standard Library: encoding/json",
+      "code": "// JSON\nimport \"encoding/json\"\ntype Person struct {\n  Name string `json:\"name\"`\n  Age  int    `json:\"age\"`\n}\ndata, err := json.Marshal(person)\nperson := Person{}\nerr := json.Unmarshal(data, &person)"
+    },
+    {
+      "title": "Standard Library: net/http",
+      "code": "// HTTP\nimport \"net/http\"\nhttp.HandleFunc(\"/hello\", func(w http.ResponseWriter, r *http.Request) {\n  fmt.Fprintf(w, \"Hello\")\n})\nhttp.ListenAndServe(\":8080\", nil)"
     },
     {
       "title": "Internal Packages",

--- a/src/data/go-cheatsheet/references.json
+++ b/src/data/go-cheatsheet/references.json
@@ -6,24 +6,104 @@
       "code": "// 公式 Go ドキュメント\n// https://golang.org/doc/\n\n// Go 標準ライブラリ\n// https://golang.org/pkg/\n\n// Go Tour - インタラクティブチュートリアル\n// https://tour.golang.org/\n\n// Effective Go - ベストプラクティス\n// https://golang.org/doc/effective_go.html\n\n// Go by Example - 実用的な例\n// https://gobyexample.com/\n\n// Go 言語仕様\n// https://golang.org/ref/spec\n\n// Go ブログ\n// https://go.dev/blog/\n\n// パッケージドキュメント\n// https://pkg.go.dev/\n\n// Go Playground - オンラインでコードをテスト\n// https://play.golang.org/"
     },
     {
-      "title": "Tools",
-      "code": "// Go コマンドラインツール\n// パッケージをコンパイル\ngo build\n// コンパイルして実行\ngo run\n// パッケージをテスト\ngo test\n// パッケージをダウンロードしてインストール\ngo get\n// パッケージをコンパイルしてインストール\ngo install\n// ソースコードをフォーマット\ngo fmt\n// よくある間違いを報告\ngo vet\n// モジュールメンテナンス\ngo mod\n// 新しいモジュールを初期化\ngo mod init\n// 不足しているモジュールを追加し、未使用のモジュールを削除\ngo mod tidy\n// vendor ディレクトリを作成\ngo mod vendor\n// パッケージまたはモジュールをリスト表示\ngo list\n// ワークスペースメンテナンス (Go 1.18+)\ngo work\n// ソースを処理して Go ファイルを生成\ngo generate\n// パッケージまたはシンボルのドキュメントを表示\ngo doc\n// Go のバージョンを表示\ngo version\n\n// 環境変数\n// モジュールサポートを制御\nGO111MODULE\n// ワークスペースディレクトリ (モジュールを使用しない場合)\nGOPATH\n// Go のインストールディレクトリ\nGOROOT\n// Go バイナリのインストールディレクトリ\nGOBIN\n// クロスコンパイルのためのターゲット OS/アーキテクチャ\nGOOS/GOARCH\n// 'go' コマンドのデフォルトフラグ\nGOFLAGS"
+      "title": "Go Command-Line Tools",
+      "code": "// Go コマンドラインツール\n// パッケージをコンパイル\ngo build\n// コンパイルして実行\ngo run\n// パッケージをテスト\ngo test\n// パッケージをダウンロードしてインストール\ngo get\n// パッケージをコンパイルしてインストール\ngo install\n// ソースコードをフォーマット\ngo fmt\n// よくある間違いを報告\ngo vet\n// モジュールメンテナンス\ngo mod\n// 新しいモジュールを初期化\ngo mod init\n// 不足しているモジュールを追加し、未使用のモジュールを削除\ngo mod tidy\n// vendor ディレクトリを作成\ngo mod vendor\n// パッケージまたはモジュールをリスト表示\ngo list\n// ワークスペースメンテナンス (Go 1.18+)\ngo work\n// ソースを処理して Go ファイルを生成\ngo generate\n// パッケージまたはシンボルのドキュメントを表示\ngo doc\n// Go のバージョンを表示\ngo version"
     },
     {
-      "title": "Code Style",
-      "code": "// Go コードスタイルガイド\n\n// 変数 - 短く、説明的な名前を使用\n// 読みやすさのために宣言をグループ化\nvar (\n  userCount int\n  maxRetries = 3\n// エラー変数: err + 説明\n  errNotFound = errors.New(\"not found\")\n)\n\n// 定数 - 定数には camelCase または ALL_CAPS を使用\nconst (\n  maxConnections = 100\n// 非常に重要な定数には ALL_CAPS\n  DEFAULT_TIMEOUT = 30 * time.Second\n)\n\n// 関数 - アンダースコアではなく MixedCaps を使用\nfunc ConnectToDatabase(config *DatabaseConfig) (*Connection, error) {\n  // ...\n}\n\n// インターフェース - 単一メソッドのインターフェースは -er で終わる\ntype Reader interface {\n  Read(p []byte) (n int, err error)\n}\n\n// エラー処理 - エラーをすぐにチェック\nresult, err := DoSomething()\nif err != nil {\n  return nil, fmt.Errorf(\"failed to do something: %w\", err)\n}\n\n// コメント - ドキュメント化するものの名前で始める\n// User はシステム内のユーザーを表す。\ntype User struct {\n  // ...\n}\n\n// GetByID は ID によってユーザーを取得する。\nfunc GetByID(id string) (*User, error) {\n  // ...\n}\n\n// インデント - スペースではなくタブを使用\nfunc example() {\n\tif condition {\n\t\tfmt.Println(\"indented with tabs\")\n\t}\n}"
+      "title": "Go Environment Variables",
+      "code": "// 環境変数\n// モジュールサポートを制御\nGO111MODULE\n// ワークスペースディレクトリ (モジュールを使用しない場合)\nGOPATH\n// Go のインストールディレクトリ\nGOROOT\n// Go バイナリのインストールディレクトリ\nGOBIN\n// クロスコンパイルのためのターゲット OS/アーキテクチャ\nGOOS/GOARCH\n// 'go' コマンドのデフォルトフラグ\nGOFLAGS"
     },
     {
-      "title": "Best Practices",
-      "code": "// Go ベストプラクティス\n\n// 1. エラーを明示的に処理する\nif err := doSomething(); err != nil {\n  // エラーを処理し、無視しない\n  log.Printf(\"error: %v\", err)\n  return err\n}\n\n// 2. 継承よりもコンポジションを優先する\ntype Logger struct {\n  // ...\n}\n\ntype Server struct {\n// 拡張する代わりに埋め込む\n  Logger\n  // ...\n}\n\n// 3. 依存性注入にインターフェースを使用する\ntype UserStore interface {\n  GetUser(id string) (*User, error)\n}\n\nfunc NewUserHandler(store UserStore) *UserHandler {\n  return &UserHandler{store: store}\n}\n\n// 4. キャンセルとデッドラインに context を使用する\nctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)\ndefer cancel()\n\nresult, err := service.DoWork(ctx)\n\n// 5. 可能な限りパッケージレベルの状態を避ける\n// 悪い例:\nvar db *sql.DB\n\n// より良い例:\ntype Service struct {\n  db *sql.DB\n}\n\n// 6. クリーンアップに defer を使用する\nf, err := os.Open(filename)\nif err != nil {\n  return err\n}\n// エラーパスでも常に閉じる\ndefer f.Close()\n\n// 7. インターフェース定義を実装から分離する\n// 実装レベルではなく、ユーザーレベルでインターフェースを定義する\n\n// 8. gofmt, goimports, golint, go vet を使用する\n// コードを一貫してフォーマットし、一般的なエラーをキャッチする"
+      "title": "Code Style: Variables",
+      "code": "// 変数 - 短く、説明的な名前を使用\n// 読みやすさのために宣言をグループ化\nvar (\n  userCount int\n  maxRetries = 3\n// エラー変数: err + 説明\n  errNotFound = errors.New(\"not found\")\n)"
     },
     {
-      "title": "Testing",
-      "code": "// Go テストパターン\n// 別のテストパッケージ\npackage mypackage_test\n\nimport (\n  \"testing\"\n\n  \"example.com/mypackage\"\n)\n\n// 基本的なテスト関数\nfunc TestAdd(t *testing.T) {\n  got := mypackage.Add(2, 3)\n  want := 5\n  if got != want {\n    t.Errorf(\"Add(2, 3) = %d; want %d\", got, want)\n  }\n}\n\n// テーブル駆動テスト\nfunc TestAdd_Table(t *testing.T) {\n  tests := []struct {\n    name string\n    a, b int\n    want int\n  }{\n    {\"positive\", 2, 3, 5},\n    {\"negative\", -1, -2, -3},\n    {\"mixed\", -1, 5, 4},\n  }\n\n  for _, tt := range tests {\n    t.Run(tt.name, func(t *testing.T) {\n      got := mypackage.Add(tt.a, tt.b)\n      if got != tt.want {\n        t.Errorf(\"Add(%d, %d) = %d; want %d\", tt.a, tt.b, got, tt.want)\n      }\n    })\n  }\n}\n\n// ベンチマーク\nfunc BenchmarkAdd(b *testing.B) {\n  for i := 0; i < b.N; i++ {\n    mypackage.Add(2, 3)\n  }\n}\n\n// テストの実行:\n// $ go test\n// $ go test -v\n// $ go test -run=TestAdd\n// $ go test -bench=.\n// $ go test -cover\n\n// テスト可能な例 (ドキュメントとテスト)\nfunc ExampleAdd() {\n  sum := mypackage.Add(1, 2)\n  fmt.Println(sum)\n  // Output: 3\n}\n\n// モック\ntype mockUserStore struct {\n  users map[string]*User\n}\n\nfunc (m *mockUserStore) GetUser(id string) (*User, error) {\n  user, ok := m.users[id]\n  if !ok {\n    return nil, errors.New(\"user not found\")\n  }\n  return user, nil\n}\n\n// モックを使用したテスト\nfunc TestHandler_GetUser(t *testing.T) {\n  // モックを設定\n  store := &mockUserStore{\n    users: map[string]*User{\n      \"123\": {ID: \"123\", Name: \"Test User\"},\n    },\n  }\n  \n  // モックを注入\n  handler := NewUserHandler(store)\n  \n  // テスト\n  user, err := handler.GetUser(\"123\")\n  if err != nil {\n    t.Fatalf(\"expected no error, got %v\", err)\n  }\n  if user.Name != \"Test User\" {\n    t.Errorf(\"expected name 'Test User', got '%s'\", user.Name)\n  }\n}"
+      "title": "Code Style: Constants",
+      "code": "// 定数 - 定数には camelCase または ALL_CAPS を使用\nconst (\n  maxConnections = 100\n// 非常に重要な定数には ALL_CAPS\n  DEFAULT_TIMEOUT = 30 * time.Second\n)"
     },
     {
-      "title": "Common Patterns",
-      "code": "// 関数オプションパターン\ntype ServerOption func(*Server)\n\nfunc WithTimeout(timeout time.Duration) ServerOption {\n  return func(s *Server) {\n    s.timeout = timeout\n  }\n}\n\nfunc WithTLS(cert, key string) ServerOption {\n  return func(s *Server) {\n    s.useTLS = true\n    s.cert = cert\n    s.key = key\n  }\n}\n\nfunc NewServer(addr string, opts ...ServerOption) *Server {\n  // デフォルト設定\n  server := &Server{\n    addr:    addr,\n    timeout: 30 * time.Second,\n  }\n  \n  // オプションを適用\n  for _, opt := range opts {\n    opt(server)\n  }\n  \n  return server\n}\n\n// 使用法\nserver := NewServer(\":8080\",\n  WithTimeout(10*time.Second),\n  WithTLS(\"cert.pem\", \"key.pem\"),\n)\n\n// ワーカープールパターン\nfunc worker(id int, jobs <-chan Job, results chan<- Result) {\n  for job := range jobs {\n    results <- process(job)\n  }\n}\n\n// プールを作成\njobs := make(chan Job, 100)\nresults := make(chan Result, 100)\n\n// ワーカーを開始\nfor w := 1; w <= 3; w++ {\n  go worker(w, jobs, results)\n}\n\n// ジョブを送信し、結果を収集\nfor _, j := range allJobs {\n  jobs <- j\n}\nclose(jobs)\n\n// 結果を収集\nfor range allJobs {\n  result := <-results\n  // 結果を使用\n}"
+      "title": "Code Style: Functions",
+      "code": "// 関数 - アンダースコアではなく MixedCaps を使用\nfunc ConnectToDatabase(config *DatabaseConfig) (*Connection, error) {\n  // ...\n}"
+    },
+    {
+      "title": "Code Style: Interfaces",
+      "code": "// インターフェース - 単一メソッドのインターフェースは -er で終わる\ntype Reader interface {\n  Read(p []byte) (n int, err error)\n}"
+    },
+    {
+      "title": "Code Style: Error Handling",
+      "code": "// エラー処理 - エラーをすぐにチェック\nresult, err := DoSomething()\nif err != nil {\n  return nil, fmt.Errorf(\"failed to do something: %w\", err)\n}"
+    },
+    {
+      "title": "Code Style: Comments",
+      "code": "// コメント - ドキュメント化するものの名前で始める\n// User はシステム内のユーザーを表す。\ntype User struct {\n  // ...\n}\n\n// GetByID は ID によってユーザーを取得する。\nfunc GetByID(id string) (*User, error) {\n  // ...\n}"
+    },
+    {
+      "title": "Code Style: Indentation",
+      "code": "// インデント - スペースではなくタブを使用\nfunc example() {\n\tif condition {\n\t\tfmt.Println(\"indented with tabs\")\n\t}\n}"
+    },
+    {
+      "title": "Best Practice: Handle Errors Explicitly",
+      "code": "// 1. エラーを明示的に処理する\nif err := doSomething(); err != nil {\n  // エラーを処理し、無視しない\n  log.Printf(\"error: %v\", err)\n  return err\n}"
+    },
+    {
+      "title": "Best Practice: Favor Composition",
+      "code": "// 2. 継承よりもコンポジションを優先する\ntype Logger struct {\n  // ...\n}\n\ntype Server struct {\n// 拡張する代わりに埋め込む\n  Logger\n  // ...\n}"
+    },
+    {
+      "title": "Best Practice: Use Interfaces for DI",
+      "code": "// 3. 依存性注入にインターフェースを使用する\ntype UserStore interface {\n  GetUser(id string) (*User, error)\n}\n\nfunc NewUserHandler(store UserStore) *UserHandler {\n  return &UserHandler{store: store}\n}"
+    },
+    {
+      "title": "Best Practice: Use Context",
+      "code": "// 4. キャンセルとデッドラインに context を使用する\nctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)\ndefer cancel()\n\nresult, err := service.DoWork(ctx)"
+    },
+    {
+      "title": "Best Practice: Avoid Package State",
+      "code": "// 5. 可能な限りパッケージレベルの状態を避ける\n// 悪い例:\nvar db *sql.DB\n\n// より良い例:\ntype Service struct {\n  db *sql.DB\n}"
+    },
+    {
+      "title": "Best Practice: Use defer for Cleanup",
+      "code": "// 6. クリーンアップに defer を使用する\nf, err := os.Open(filename)\nif err != nil {\n  return err\n}\n// エラーパスでも常に閉じる\ndefer f.Close()"
+    },
+    {
+      "title": "Best Practice: Separate Interface Definitions",
+      "code": "// 7. インターフェース定義を実装から分離する\n// 実装レベルではなく、ユーザーレベルでインターフェースを定義する"
+    },
+    {
+      "title": "Best Practice: Use Go Tools",
+      "code": "// 8. gofmt, goimports, golint, go vet を使用する\n// コードを一貫してフォーマットし、一般的なエラーをキャッチする"
+    },
+    {
+      "title": "Basic Test Function",
+      "code": "// Go テストパターン\n// 別のテストパッケージ\npackage mypackage_test\n\nimport (\n  \"testing\"\n  \"example.com/mypackage\"\n)\n\n// 基本的なテスト関数\nfunc TestAdd(t *testing.T) {\n  got := mypackage.Add(2, 3)\n  want := 5\n  if got != want {\n    t.Errorf(\"Add(2, 3) = %d; want %d\", got, want)\n  }\n}"
+    },
+    {
+      "title": "Table-Driven Tests",
+      "code": "// テーブル駆動テスト\nfunc TestAdd_Table(t *testing.T) {\n  tests := []struct {\n    name string\n    a, b int\n    want int\n  }{\n    {\"positive\", 2, 3, 5},\n    {\"negative\", -1, -2, -3},\n    {\"mixed\", -1, 5, 4},\n  }\n\n  for _, tt := range tests {\n    t.Run(tt.name, func(t *testing.T) {\n      got := mypackage.Add(tt.a, tt.b)\n      if got != tt.want {\n        t.Errorf(\"Add(%d, %d) = %d; want %d\", tt.a, tt.b, got, tt.want)\n      }\n    })\n  }\n}"
+    },
+    {
+      "title": "Benchmark Functions",
+      "code": "// ベンチマーク\nfunc BenchmarkAdd(b *testing.B) {\n  for i := 0; i < b.N; i++ {\n    mypackage.Add(2, 3)\n  }\n}"
+    },
+    {
+      "title": "Running Tests (go test)",
+      "code": "// テストの実行:\n// $ go test\n// $ go test -v\n// $ go test -run=TestAdd\n// $ go test -bench=.\n// $ go test -cover"
+    },
+    {
+      "title": "Example Tests (godoc)",
+      "code": "// テスト可能な例 (ドキュメントとテスト)\nfunc ExampleAdd() {\n  sum := mypackage.Add(1, 2)\n  fmt.Println(sum)\n  // Output: 3\n}"
+    },
+    {
+      "title": "Mocking for Tests",
+      "code": "// モック\ntype mockUserStore struct {\n  users map[string]*User\n}\n\nfunc (m *mockUserStore) GetUser(id string) (*User, error) {\n  user, ok := m.users[id]\n  if !ok {\n    return nil, errors.New(\"user not found\")\n  }\n  return user, nil\n}\n\n// モックを使用したテスト\nfunc TestHandler_GetUser(t *testing.T) {\n  // モックを設定\n  store := &mockUserStore{\n    users: map[string]*User{\n      \"123\": {ID: \"123\", Name: \"Test User\"},\n    },\n  }\n  \n  // モックを注入\n  handler := NewUserHandler(store)\n  \n  // テスト\n  user, err := handler.GetUser(\"123\")\n  if err != nil {\n    t.Fatalf(\"expected no error, got %v\", err)\n  }\n  if user.Name != \"Test User\" {\n    t.Errorf(\"expected name 'Test User', got '%s'\", user.Name)\n  }\n}"
+    },
+    {
+      "title": "Function Options Pattern",
+      "code": "// 関数オプションパターン\ntype ServerOption func(*Server)\n\nfunc WithTimeout(timeout time.Duration) ServerOption {\n  return func(s *Server) {\n    s.timeout = timeout\n  }\n}\n\nfunc WithTLS(cert, key string) ServerOption {\n  return func(s *Server) {\n    s.useTLS = true\n    s.cert = cert\n    s.key = key\n  }\n}\n\nfunc NewServer(addr string, opts ...ServerOption) *Server {\n  // デフォルト設定\n  server := &Server{\n    addr:    addr,\n    timeout: 30 * time.Second,\n  }\n  \n  // オプションを適用\n  for _, opt := range opts {\n    opt(server)\n  }\n  \n  return server\n}\n\n// 使用法\nserver := NewServer(\":8080\",\n  WithTimeout(10*time.Second),\n  WithTLS(\"cert.pem\", \"key.pem\"),\n)"
+    },
+    {
+      "title": "Worker Pool Pattern",
+      "code": "// ワーカープールパターン\nfunc worker(id int, jobs <-chan Job, results chan<- Result) {\n  for job := range jobs {\n    results <- process(job)\n  }\n}\n\n// プールを作成\njobs := make(chan Job, 100)\nresults := make(chan Result, 100)\n\n// ワーカーを開始\nfor w := 1; w <= 3; w++ {\n  go worker(w, jobs, results)\n}\n\n// ジョブを送信し、結果を収集\nfor _, j := range allJobs {\n  jobs <- j\n}\nclose(jobs)\n\n// 結果を収集\nfor range allJobs {\n  result := <-results\n  // 結果を使用\n}"
     }
   ]
 }


### PR DESCRIPTION
Split code examples within `src/data/go-cheatsheet/*.json` files into smaller, more focused topics based on comments.\nThis improves readability and makes it easier for users, especially beginners, to find specific information quickly.\n\nCloses: #14