### PR TITLE
Feat: Associate comment blocks with preceding code examples

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Copy, Check, ChevronDown, ChevronUp } from "lucide-react";
-import { Card, CardContent, CardHeader } from "@/components/ui/card"; // Removed unused CardTitle
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator"; // Import Separator
 import { useToast } from "@/hooks/use-toast";
 import {
   Collapsible,
@@ -11,21 +12,23 @@ import {
 interface CodeBlockProps {
   title: string;
   code: string;
-  language?: string; // language prop is not currently used for highlighting
+  description?: string; // Added description prop
+  language?: string;
   className?: string;
 }
 
 const CodeBlock: React.FC<CodeBlockProps> = ({
   title,
   code,
-  // language = "go", // Mark as unused for now
+  description, // Receive description
+  // language = "go",
   className = "",
 }) => {
   const [hasCopied, setHasCopied] = useState(false);
-  const [isOpen, setIsOpen] = useState(true); // Default to open based on review feedback
+  const [isOpen, setIsOpen] = useState(true);
   const { toast } = useToast();
 
-  // Simple syntax highlighting - relies on CSS classes defined in index.css
+  // Simple syntax highlighting
   const highlightCode = (codeLine: string): React.ReactNode => {
     if (!codeLine) return null;
 
@@ -40,33 +43,31 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
     // 1. Replace string literals with placeholders
     highlighted = highlighted.replace(/"([^"]*)"/g, (match) => {
       const placeholder = `__STRING_LITERAL_${stringLiterals.length}__`;
-      stringLiterals.push(match); // Store the original string literal including quotes
+      stringLiterals.push(match);
       return placeholder;
     });
 
-    // 2. Apply other highlights (keywords, types, functions, numbers) to the code *without* string literals
+    // 2. Apply other highlights
     const keywords = ["func", "package", "import", "type", "struct", "interface", "map", "chan", "const", "var", "return", "if", "else", "for", "range", "switch", "case", "default", "go", "defer", "select"];
     keywords.forEach(kw => {
       highlighted = highlighted.replace(new RegExp(`\\b${kw}\\b`, 'g'), `<span class="keyword">${kw}</span>`);
     });
-    highlighted = highlighted.replace(/\b([a-zA-Z_][a-zA-Z0-9_]*)\(/g, '<span class="function">$1</span>('); // Function calls
-    highlighted = highlighted.replace(/\b([0-9]+)\b/g, '<span class="number">$1</span>'); // Numbers
+    highlighted = highlighted.replace(/\b([a-zA-Z_][a-zA-Z0-9_]*)\(/g, '<span class="function">$1</span>(');
+    highlighted = highlighted.replace(/\b([0-9]+)\b/g, '<span class="number">$1</span>');
     const types = ["string", "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64", "uintptr", "float32", "float64", "complex64", "complex128", "bool", "byte", "rune", "error"];
     types.forEach(t => {
       highlighted = highlighted.replace(new RegExp(`\\b${t}\\b`, 'g'), `<span class="type">${t}</span>`);
     });
 
-    // 3. Restore string literals with highlighting span
+    // 3. Restore string literals
     stringLiterals.forEach((literal, index) => {
       const placeholder = `__STRING_LITERAL_${index}__`;
-      // Extract content inside quotes for the span
       const content = literal.substring(1, literal.length - 1);
       highlighted = highlighted.replace(placeholder, `<span class="string">"${content}"</span>`);
     });
 
     return <span dangerouslySetInnerHTML={{ __html: highlighted }} />;
   };
-
 
   const handleCopy = async () => {
     try {
@@ -89,12 +90,13 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
     }
   };
 
+  // Render code block content, including description if available
   const renderCodeContent = () => (
-    <CardContent className="code-content relative pt-2 pb-4 px-4 font-mono rounded-b-lg"> {/* Consistent styling, relative is already here */}
-      {/* Unified Copy Button - Moved inside CardContent */}
+    <CardContent className="code-content relative pt-2 pb-4 px-4 font-mono rounded-b-lg">
+      {/* Copy Button */}
       <button
         onClick={handleCopy}
-        className="absolute top-2 right-2 p-1.5 text-muted-foreground hover:text-foreground transition-colors rounded-md z-10" /* Style from no-title case */
+        className="absolute top-2 right-2 p-1.5 text-muted-foreground hover:text-foreground transition-colors rounded-md z-10"
         aria-label="Copy code"
       >
         {hasCopied ? <Check size={14} /> : <Copy size={14} />}
@@ -109,14 +111,21 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
             </div>
           ))}
         </pre>
+        {/* Render description below code if it exists */}
+        {description && (
+          <>
+            <Separator className="my-3 bg-border/50" />
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap font-sans">
+              {description}
+            </p>
+          </>
+        )}
       </div>
     </CardContent>
   );
 
   return (
-    <Card className={`relative code-block overflow-hidden ${className}`}> {/* relative was already added */}
-      {/* Copy Button removed from here */}
-
+    <Card className={`relative code-block overflow-hidden ${className}`}>
       {title ? (
         <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
           {/* Header */}
@@ -138,7 +147,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
           </CollapsibleContent>
         </Collapsible>
       ) : (
-        // Render code content directly if no title
+        // Render content directly if no title
         renderCodeContent()
       )}
     </Card>

--- a/src/data/cheatsheet-loader.ts
+++ b/src/data/cheatsheet-loader.ts
@@ -34,7 +34,7 @@ export const cheatSheetSectionOrder = [
 
 // セクション名とデータのマッピング
 // コードがコメントのみか判定するヘルパー関数
-function isCodeCommentOnly(code: string): boolean {
+function isCommentBlock(code: string): boolean {
   const trimmedCode = code.trim();
   if (trimmedCode === '') {
     return true; // 空文字列はコメントのみとみなす
@@ -47,7 +47,7 @@ function isCodeCommentOnly(code: string): boolean {
 }
 
 // コメント内容を整形するヘルパー関数
-function formatCommentContent(commentCode: string): string {
+function formatCommentBlock(commentCode: string): string {
   return commentCode
     .split('\n')
     .map(line => line.trim().replace(/^\/\/\s*/, '')) // Remove '// ' or '//'
@@ -81,10 +81,10 @@ for (const [sectionId, sectionData] of Object.entries(importedData)) {
   let previousExample: { title: string; code: string; description?: string } | null = null;
 
   for (const currentExample of sectionData.codeExamples) {
-    if (isCodeCommentOnly(currentExample.code)) {
+    if (isCommentBlock(currentExample.code)) {
       // コメントのみのブロックの場合、前のブロックの description に設定
       if (previousExample) {
-        previousExample.description = formatCommentContent(currentExample.code);
+        previousExample.description = formatCommentBlock(currentExample.code);
       }
       // コメントのみのブロック自体は processedExamples に追加しない
     } else {

--- a/src/data/cheatsheet-loader.ts
+++ b/src/data/cheatsheet-loader.ts
@@ -33,22 +33,73 @@ export const cheatSheetSectionOrder = [
 ];
 
 // セクション名とデータのマッピング
-const sectionDataMap: Record<string, CheatSheetSection> = {
-  'basics': basicsData as CheatSheetSection,
-  'basic-types': basicTypesData as CheatSheetSection,
-  'flow-control': flowControlData as CheatSheetSection,
-  'functions': functionsData as CheatSheetSection,
-  'data-structures': dataStructuresData as CheatSheetSection,
-  'packages': packagesData as CheatSheetSection,
-  'concurrency': concurrencyData as CheatSheetSection,
-  'context': contextData as CheatSheetSection,
-  'error-handling': errorHandlingData as CheatSheetSection,
-  'methods': methodsData as CheatSheetSection,
-  'interfaces': interfacesData as CheatSheetSection,
-  'io-operations': ioOperationsData as CheatSheetSection,
-  'generics': genericsData as CheatSheetSection,
-  'references': referencesData as CheatSheetSection
+// コードがコメントのみか判定するヘルパー関数
+function isCodeCommentOnly(code: string): boolean {
+  const trimmedCode = code.trim();
+  if (trimmedCode === '') {
+    return true; // 空文字列はコメントのみとみなす
+  }
+  return trimmedCode.split('\n').every(line => {
+    const trimmedLine = line.trim();
+    // コメント行または空行かチェック
+    return trimmedLine.startsWith('//') || trimmedLine === '';
+  });
+}
+
+// コメント内容を整形するヘルパー関数
+function formatCommentContent(commentCode: string): string {
+  return commentCode
+    .split('\n')
+    .map(line => line.trim().replace(/^\/\/\s*/, '')) // Remove '// ' or '//'
+    .filter(line => line.trim() !== '') // Remove empty lines
+    .join('\n');
+}
+
+
+// 元のデータを一時的に保持
+const importedData: Record<string, { title: string; codeExamples: { title: string; code: string }[] }> = {
+  'basics': basicsData,
+  'basic-types': basicTypesData,
+  'flow-control': flowControlData,
+  'functions': functionsData,
+  'data-structures': dataStructuresData,
+  'packages': packagesData,
+  'concurrency': concurrencyData,
+  'context': contextData,
+  'error-handling': errorHandlingData,
+  'methods': methodsData,
+  'interfaces': interfacesData,
+  'io-operations': ioOperationsData,
+  'generics': genericsData,
+  'references': referencesData
 };
+
+// description プロパティを追加し、コメントのみのブロックを処理して新しいマップを作成
+const sectionDataMap: Record<string, CheatSheetSection> = {};
+for (const [sectionId, sectionData] of Object.entries(importedData)) {
+  const processedExamples: { title: string; code: string; description?: string }[] = [];
+  let previousExample: { title: string; code: string; description?: string } | null = null;
+
+  for (const currentExample of sectionData.codeExamples) {
+    if (isCodeCommentOnly(currentExample.code)) {
+      // コメントのみのブロックの場合、前のブロックの description に設定
+      if (previousExample) {
+        previousExample.description = formatCommentContent(currentExample.code);
+      }
+      // コメントのみのブロック自体は processedExamples に追加しない
+    } else {
+      // 通常のコードブロックの場合
+      const newExample = { ...currentExample, description: undefined }; // description を初期化
+      processedExamples.push(newExample);
+      previousExample = newExample; // 次の反復のために保持
+    }
+  }
+
+  sectionDataMap[sectionId] = {
+    ...sectionData,
+    codeExamples: processedExamples,
+  };
+}
 
 // チートシートの全データを順序通りに取得
 export function getCheatSheetData(): CheatSheetSection[] {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,6 +1,8 @@
 export interface CodeExample {
   title: string;
   code: string;
+  description?: string;
+  isCommentOnly?: boolean;
 }
 
 export interface CheatSheetSection {


### PR DESCRIPTION
This PR implements the logic to treat comment-only code blocks as descriptions for the preceding code example.

**Changes:**

*   Added `description` field to `CodeExample` type in `src/data/types.ts`.
*   Modified `src/data/cheatsheet-loader.ts`:
    *   Detects comment-only blocks.
    *   Formats their content.
    *   Assigns the formatted content to the `description` field of the previous example.
    *   Removes the original comment-only block from the data.
*   Updated `src/components/CodeBlock.tsx`:
    *   Accepts the `description` prop.
    *   Displays the description below the code block, separated by a `<Separator />`.

Closes #16