### PR TITLE
feat: remove theme switching and enforce light mode

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import GoLogo from './GoLogo';
-import { Github, ExternalLink, Sun, Moon } from 'lucide-react'; // Added Sun, Moon
-import { useTheme } from '@/hooks/use-theme'; // Import the custom hook
-import { Button } from "@/components/ui/button"; // Import Button
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"; // Import DropdownMenu components
+import { Github, ExternalLink } from 'lucide-react'; // Removed Sun, Moon
+// import { useTheme } from '@/hooks/use-theme'; // Removed useTheme import
+// import { Button } from "@/components/ui/button"; // Removed Button import
+// Removed DropdownMenu imports
 
 const Header = () => {
   const [scrolled, setScrolled] = useState(false);
-  const { theme, setTheme } = useTheme(); // Use the theme hook
+  // const { theme, setTheme } = useTheme(); // Removed useTheme usage
 
   useEffect(() => {
     const handleScroll = () => {
@@ -34,7 +29,7 @@ const Header = () => {
     <header
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ease-in-out
       ${scrolled
-        ? 'bg-background/90 dark:bg-background/80 backdrop-blur-md shadow-sm py-3'
+        ? 'bg-background/90 backdrop-blur-md shadow-sm py-3' // Removed dark:bg-background/80
         : 'bg-transparent py-5'
       }`}
     >
@@ -56,7 +51,7 @@ const Header = () => {
             <span>公式サイト</span>
           </a>
           <a
-            href="https://github.com/your-repo/go-cheat-sheet-garden" // TODO: Update with actual repo URL
+            href="https://github.com/tKwbr999/go-cheat-sheet-garden" // Updated repo URL
             target="_blank"
             rel="noopener noreferrer"
             className="hidden sm:flex items-center text-sm text-muted-foreground hover:text-primary transition-colors duration-200" // Hide on small screens
@@ -65,27 +60,7 @@ const Header = () => {
             <span>GitHub</span>
           </a>
 
-          {/* Theme Toggle Dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-                <span className="sr-only">Toggle theme</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => setTheme('light')}>
-                Light
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme('dark')}>
-                Dark
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme('system')}>
-                System
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {/* Theme Toggle Dropdown Removed */}
         </div>
       </div>
     </header>

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,56 +1,36 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 
-type Theme = 'light' | 'dark' | 'system';
+// Theme type is no longer needed as we enforce 'light'
+// type Theme = 'light' | 'dark' | 'system';
 
 export function useTheme() {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    if (typeof window === 'undefined') {
-      return 'system'; // Default for SSR or build time
+  // State is no longer needed, but we keep the hook structure
+  // const [theme, setThemeState] = useState<Theme>('light'); // Always light
+
+  const applyTheme = useCallback(() => {
+    // Always apply 'light' theme
+    if (typeof window !== 'undefined') {
+      const root = window.document.documentElement;
+      root.classList.remove('dark'); // Ensure dark class is removed if present
+      root.classList.add('light'); // Always add light class
+      // localStorage interaction is removed
+      // localStorage.setItem('theme', 'light');
     }
-    return (localStorage.getItem('theme') as Theme) || 'system';
-  });
-
-  const applyTheme = useCallback((selectedTheme: Theme) => {
-    const root = window.document.documentElement;
-    root.classList.remove('light', 'dark');
-
-    let effectiveTheme: 'light' | 'dark';
-    if (selectedTheme === 'system') {
-      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      effectiveTheme = systemPrefersDark ? 'dark' : 'light';
-    } else {
-      effectiveTheme = selectedTheme;
-    }
-
-    root.classList.add(effectiveTheme);
-    localStorage.setItem('theme', selectedTheme); // Store the user's preference (light, dark, or system)
-    setThemeState(selectedTheme); // Update the hook's state
+    // setThemeState('light'); // State update is removed
   }, []);
 
-  // Effect to apply theme on initial load and when theme state changes
+  // Effect to apply theme on initial load
   useEffect(() => {
-    applyTheme(theme);
-  }, [theme, applyTheme]);
+    applyTheme();
+  }, [applyTheme]);
 
-  // Effect to listen for system theme changes when theme is 'system'
-  useEffect(() => {
-    if (theme !== 'system') {
-      return;
-    }
+  // System theme listener effect is removed
 
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleChange = () => {
-      // Re-apply theme which will detect the new system preference
-      applyTheme('system');
-    };
+  // setTheme function is removed as theme is fixed
+  // const setTheme = (newTheme: Theme) => {
+  //   applyTheme(newTheme);
+  // };
 
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, [theme, applyTheme]);
-
-  const setTheme = (newTheme: Theme) => {
-    applyTheme(newTheme);
-  };
-
-  return { theme, setTheme };
+  // Return a fixed theme value and a no-op setter
+  return { theme: 'light' as const /*, setTheme: () => {} */ };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -45,47 +45,6 @@
 
     --radius: 0.5rem;
   }
-
-  .dark {
-    /* --- Dark Mode: Twine Theme --- */
-    --background: #321916; /* twine-950 */
-    --foreground: #eee3d3; /* twine-100 */
-
-    --card: #57322c; /* twine-900 */
-    --card-foreground: #eee3d3; /* twine-100 */
-
-    --popover: #321916; /* twine-950 */
-    --popover-foreground: #eee3d3; /* twine-100 */
-
-    /* Keep original colors for syntax highlighting */
-    --primary-syntax: 210 30% 70%;
-    --accent-syntax: 145 30% 60%;
-    --destructive-syntax: 0 60% 55%;
-    --secondary-syntax-fg: 40 15% 80%;
-    --muted-syntax-fg: 40 10% 60%;
-
-    /* UI Colors (Twine Scale) */
-    --primary: #cca378; /* twine-300 */
-    --primary-foreground: #321916; /* twine-950 */
-
-    --secondary: #65392e; /* twine-800 */
-    --secondary-foreground: #dfc7a9; /* twine-200 */
-
-    --muted: #65392e; /* twine-800 */
-    --muted-foreground: #c39265; /* twine-400 */
-
-    --accent: #ad7345; /* twine-500 */
-    --accent-foreground: #321916; /* twine-950 */
-
-    --destructive: #c39265; /* twine-400 */
-    --destructive-foreground: #321916; /* twine-950 */
-
-    --border: #774431; /* twine-700 */
-    --input: #774431; /* twine-700 */
-    --ring: #945a3a; /* twine-600 */
-    /* --radius is inherited from :root */
-  }
-
   * {
     @apply border-border antialiased;
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,7 @@ import tailwindcssAnimate from "tailwindcss-animate";
 import type { Config } from "tailwindcss";
 
 export default {
-  darkMode: ["class"],
+  // darkMode: ["class"], // This line is removed
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",


### PR DESCRIPTION
テーマ切り替え機能（Light/Dark/System）を削除し、アプリケーション全体でLightモードを強制するようにしました。

**変更点:**
- `src/hooks/use-theme.ts`: Lightテーマのみを適用するように簡略化。
- `src/components/Header.tsx`: テーマ切り替えUIを削除。
- `tailwind.config.ts`: `darkMode` 設定を削除。
- `src/index.css`: `.dark` スタイル定義を削除。

Closes #43