### PR TITLE
Refactor: 静的データ移行後の不要コードをクリーンアップ

### DIFF
--- a/src/components/CheatSheetSection.tsx
+++ b/src/components/CheatSheetSection.tsx
@@ -4,9 +4,6 @@ import type { CheatSheetSection as SectionData, CodeExample } from "@/data/types
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface CheatSheetSectionProps {
-  // title と sectionId は sectionData から取得できるため Props から削除可能
-  // title: string;
-  // sectionId: string;
   sectionData: SectionData & { id: string }; // 完全なデータを受け取る
   className?: string;
 }

--- a/src/data/cheatsheet.ts
+++ b/src/data/cheatsheet.ts
@@ -1,7 +1,0 @@
-// このファイルは後方互換性のために残しています
-// 新しいデータ構造は data/cheatsheet-loader.ts を使用してください
-import { CheatSheetSection } from "./types";
-import { getCheatSheetData } from "./cheatsheet-loader";
-
-// 互換性のためにデータをエクスポート
-export const cheatSheetData: CheatSheetSection[] = getCheatSheetData();


### PR DESCRIPTION
静的データ (bundledCheatSheetData) への移行後に残った不要なファイル (`src/data/cheatsheet.ts`) とコード (`src/components/CheatSheetSection.tsx` 内のコメント) を削除します。\n\nCloses: #55