### PR TITLE
chore: Run bundle-data before dev and build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "build:dev": "vite build --mode development",
+    "dev": "bun run bundle-data && vite",
+    "build": "bun run bundle-data && vite build",
+    "build:dev": "bun run bundle-data && vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
     "bundle-data": "bun run scripts/bundle-cheatsheet-data.ts"

--- a/src/components/CheatSheetSection.tsx
+++ b/src/components/CheatSheetSection.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import CodeBlock from "./CodeBlock";
 import type { CheatSheetSection as SectionData } from "@/data/types";
 
@@ -23,11 +24,15 @@ const CheatSheetSection: React.FC<CheatSheetSectionProps> = ({
       <div className="flex items-center justify-between mb-4">
         <h2 className="section-title">{title}</h2>
       </div>
-      <div className="code-grid grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4"> {/* Changed lg:grid-cols-3 to lg:grid-cols-2 */}
+      <div className="code-grid grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
+        {" "}
+        {/* Changed lg:grid-cols-3 to lg:grid-cols-2 */}
         {/* データは常に存在するので、ローディングやエラー表示は不要 */}
         {codeExamples.length > 0 ? (
           codeExamples.map((example, index) => (
-            <div key={example.title + index} className="min-w-[300px]"> {/* Add min-width */}
+            <div key={example.title + index} className="min-w-[300px]">
+              {" "}
+              {/* Add min-width */}
               <CodeBlock
                 title={example.title}
                 code={example.code}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -59,7 +59,7 @@ const Header = () => {
             className="hidden sm:flex items-center text-sm text-muted-foreground hover:text-primary transition-colors duration-200" // Hide on small screens
           >
             <img
-              src="/github-mark.svg"
+              src={`${import.meta.env.BASE_URL}github-mark.svg`}
               alt="GitHub"
               width={18}
               height={18}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,7 +58,13 @@ const Header = () => {
             rel="noopener noreferrer"
             className="hidden sm:flex items-center text-sm text-muted-foreground hover:text-primary transition-colors duration-200" // Hide on small screens
           >
-            <img src="/public/github-mark.svg" alt="GitHub" width={18} height={18} className="mr-1" />
+            <img
+              src="/github-mark.svg"
+              alt="GitHub"
+              width={18}
+              height={18}
+              className="mr-1"
+            />
             <span>GitHub</span>
           </a>
           {/* Theme Toggle Dropdown Removed */}

--- a/src/components/SectionLoader.tsx
+++ b/src/components/SectionLoader.tsx
@@ -38,7 +38,7 @@ const SectionLoaderComponent: React.FC<SectionLoaderProps> = ({ sectionId, measu
       // setSectionData(null);
 
       try {
-        const response = await fetch(`/data/sections/${sectionId}.json`);
+        const response = await fetch(`${import.meta.env.BASE_URL}data/sections/${sectionId}.json`);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -14,7 +14,11 @@ interface TableOfContentsProps {
   className?: string;
 }
 
-const TableOfContents: React.FC<TableOfContentsProps> = ({ sections, className }) => { // props から sections を受け取る
+const TableOfContents: React.FC<TableOfContentsProps> = ({
+  sections,
+  className,
+}) => {
+  // props から sections を受け取る
   const [activeSectionId, setActiveSectionId] = useState<string | null>(null);
   // bundledCheatSheetData からの生成を削除
   const observerRef = useRef<IntersectionObserver | null>(null);
@@ -75,16 +79,15 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({ sections, className }
 
     // Observe elements after a short delay to ensure they are in the DOM
     const timeoutId = setTimeout(() => {
-        // props から渡された sections を使用
-        sections.forEach((section) => {
-            const element = document.getElementById(section.id);
-            if (element) {
-                sectionRefs.current.set(section.id, element); // Update ref map just in case
-                currentObserver.observe(element);
-            }
-        });
+      // props から渡された sections を使用
+      sections.forEach((section) => {
+        const element = document.getElementById(section.id);
+        if (element) {
+          sectionRefs.current.set(section.id, element); // Update ref map just in case
+          currentObserver.observe(element);
+        }
+      });
     }, 100); // Delay to ensure DOM elements are ready
-
 
     return () => {
       clearTimeout(timeoutId);
@@ -114,13 +117,14 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({ sections, className }
   return (
     <nav
       className={cn(
-        "sticky top-20 h-[calc(100vh-5rem)] overflow-y-auto pt-0 pr-4 pb-4 pl-4 border-r hidden lg:block w-64", // feat/64 のクラス名を採用
+        "sticky h-[calc(100vh-5rem)] overflow-y-auto pt-0 pr-4 pb-4 pl-4 border-r hidden lg:block w-64", // feat/64 のクラス名を採用
         className
       )}
     >
-      {" "}
       {/* Changed border-l to border-r */}
-      <h3 className="text-lg font-semibold mb-4 text-foreground"> {/* feat/64 のクラス名を採用 */}
+      <h3 className="text-lg font-semibold mb-4 text-foreground">
+        {" "}
+        {/* feat/64 のクラス名を採用 */}
         Table of Contents
       </h3>{" "}
       {/* Ensure text color contrast */}

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -77,20 +77,18 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({
 
     const currentObserver = observerRef.current; // Capture observer instance
 
-    // Observe elements after a short delay to ensure they are in the DOM
-    const timeoutId = setTimeout(() => {
-      // props から渡された sections を使用
-      sections.forEach((section) => {
-        const element = document.getElementById(section.id);
-        if (element) {
-          sectionRefs.current.set(section.id, element); // Update ref map just in case
-          currentObserver.observe(element);
-        }
-      });
-    }, 100); // Delay to ensure DOM elements are ready
+    // Observe elements directly after observer is created
+    // props から渡された sections を使用
+    sections.forEach((section) => {
+      const element = document.getElementById(section.id);
+      if (element) {
+        sectionRefs.current.set(section.id, element); // Update ref map just in case
+        currentObserver.observe(element);
+      }
+    });
 
     return () => {
-      clearTimeout(timeoutId);
+      // clearTimeout(timeoutId); // setTimeout removed
       if (currentObserver) {
         currentObserver.disconnect();
       }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -81,56 +81,53 @@ const Index = () => {
       <Header />
 
       {/* Main content section with Table of Contents */}
-      {/* スクロールコンテナ (HEAD) */}
-      <div ref={parentRef} className="flex-1 overflow-auto">
-        {/* pt-8 を採用 (HEAD) */}
-        <section className="pt-8 pb-16">
-          <div className="container mx-auto max-w-10xl flex gap-4">
-            {/* Table of Contents Sidebar */}
-            {/* sections を渡す (HEAD), クラス名は feat/64 のものを TableOfContents 側で採用済み */}
-            <TableOfContents sections={sectionsManifest} className="hidden lg:block sticky top-20 h-[calc(100vh-5rem)]" />
-            {/* Main Content Area */}
-            <main className="flex-1">
-              {/* 仮想化リストのコンテナ (HEAD) */}
-              <div
-                style={{
-                  height: `${rowVirtualizer.getTotalSize()}px`,
-                  width: '100%',
-                  position: 'relative',
-                }}
-              >
-                {loadingManifest && <div>目次を読み込み中...</div>}
-                {errorManifest && <div className="text-red-500">{errorManifest}</div>}
-                {/* 仮想化されたアイテムのレンダリング (HEAD) */}
-                {rowVirtualizer.getVirtualItems().map((virtualItem) => {
-                  const sectionInfo = sectionsManifest[virtualItem.index];
-                  if (!sectionInfo) return null;
+      {/* pt-8 を採用 (HEAD) */}
+      <section className="flex-1 flex pt-8 pb-16 overflow-hidden"> {/* flex-1 と overflow-hidden を追加 */}
+        <div className="container mx-auto max-w-10xl flex gap-4 flex-1"> {/* flex-1 を追加 */}
+          {/* Table of Contents Sidebar */}
+          {/* スクロールコンテナの外に移動 */}
+          <TableOfContents sections={sectionsManifest} className="hidden lg:block sticky top-20 h-[calc(100vh-5rem-2rem)] overflow-y-auto" /> {/* h-[calc(100vh-5rem-2rem)] と overflow-y-auto を追加 */}
+          {/* Main Content Area - スクロールコンテナ */}
+          <main ref={parentRef} className="flex-1 overflow-auto"> {/* ref と overflow-auto を main に移動 */}
+            {/* 仮想化リストのコンテナ (HEAD) */}
+            <div
+              style={{
+                height: `${rowVirtualizer.getTotalSize()}px`,
+                width: '100%',
+                position: 'relative',
+              }}
+            >
+              {loadingManifest && <div>目次を読み込み中...</div>}
+              {errorManifest && <div className="text-red-500">{errorManifest}</div>}
+              {/* 仮想化されたアイテムのレンダリング (HEAD) */}
+              {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+                const sectionInfo = sectionsManifest[virtualItem.index];
+                if (!sectionInfo) return null;
 
-                  return (
-                    <div
-                      key={sectionInfo.id}
-                      ref={rowVirtualizer.measureElement} // レビューコメント対応
-                      data-index={virtualItem.index}      // レビューコメント対応
-                      style={{
-                        position: 'absolute',
-                        top: 0,
-                        left: 0,
-                        width: '100%',
-                        height: `${virtualItem.size}px`,
-                        transform: `translateY(${virtualItem.start}px)`,
-                      }}
-                      id={sectionInfo.id}
-                    >
-                      {/* SectionLoader を使用 (HEAD), props 渡し修正済み */}
-                      <SectionLoader sectionId={sectionInfo.id} measureRef={rowVirtualizer.measureElement} index={virtualItem.index} />
-                    </div>
-                  );
-                })}
-              </div>
-            </main>
-          </div>
-        </section>
-      </div>
+                return (
+                  <div
+                    key={sectionInfo.id}
+                    ref={rowVirtualizer.measureElement} // レビューコメント対応
+                    data-index={virtualItem.index}      // レビューコメント対応
+                    style={{
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: '100%',
+                      height: `${virtualItem.size}px`,
+                      transform: `translateY(${virtualItem.start}px)`,
+                    }}
+                    id={sectionInfo.id}
+                  >
+                    {/* SectionLoader を使用 (HEAD), props 渡し修正済み */}
+                    <SectionLoader sectionId={sectionInfo.id} measureRef={rowVirtualizer.measureElement} index={virtualItem.index} />
+                  </div>
+                );
+              })}
+            </div>
+          </main>
+        </div>
+      </section>
 
       {/* Footer */}
       {/* mt-auto を追加 (HEAD) */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -34,7 +34,7 @@ const Index = () => {
       try {
         setLoadingManifest(true);
         setErrorManifest(null);
-        const response = await fetch("/data/sections-manifest.json");
+        const response = await fetch(`${import.meta.env.BASE_URL}data/sections-manifest.json`);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from "react"; // useRef を追加 (HEAD)
 import Header from "@/components/Header";
 // CheatSheetSection は SectionLoader 内で使われるのでここでは不要かも
 // import CheatSheetSection from "@/components/CheatSheetSection";
-import SectionLoader from '@/components/SectionLoader';
+import SectionLoader from "@/components/SectionLoader";
 import GoLogo from "@/components/GoLogo";
 import { ArrowUp } from "lucide-react";
 // bundled-cheatsheet-data のインポートを削除 (HEAD)
@@ -19,7 +19,9 @@ interface SectionManifestItem {
 
 const Index = () => {
   const [showScrollButton, setShowScrollButton] = useState(false);
-  const [sectionsManifest, setSectionsManifest] = useState<SectionManifestItem[]>([]); // マニフェストデータ用 state (HEAD)
+  const [sectionsManifest, setSectionsManifest] = useState<
+    SectionManifestItem[]
+  >([]); // マニフェストデータ用 state (HEAD)
   const [loadingManifest, setLoadingManifest] = useState(true); // ローディング状態 (HEAD)
   const [errorManifest, setErrorManifest] = useState<string | null>(null); // エラー状態 (HEAD)
 
@@ -32,7 +34,7 @@ const Index = () => {
       try {
         setLoadingManifest(true);
         setErrorManifest(null);
-        const response = await fetch('/data/sections-manifest.json');
+        const response = await fetch("/data/sections-manifest.json");
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
@@ -77,28 +79,33 @@ const Index = () => {
   };
 
   return (
-    <div className="bg-background min-h-screen flex flex-col"> {/* flex-col を追加 (HEAD) */}
+    <div className="bg-background min-h-screen flex flex-col">
+      {" "}
+      {/* flex-col を追加 (HEAD) */}
       <Header />
-
       {/* Main content section with Table of Contents */}
-      {/* pt-8 を採用 (HEAD) */}
-      <section className="flex-1 flex pt-8 pb-16 overflow-hidden"> {/* flex-1 と overflow-hidden を追加 */}
-        <div className="container mx-auto max-w-10xl flex gap-4 flex-1"> {/* flex-1 を追加 */}
-          {/* Table of Contents Sidebar */}
-          {/* スクロールコンテナの外に移動 */}
-          <TableOfContents sections={sectionsManifest} className="hidden lg:block sticky top-20 h-[calc(100vh-5rem-2rem)] overflow-y-auto" /> {/* h-[calc(100vh-5rem-2rem)] と overflow-y-auto を追加 */}
-          {/* Main Content Area - スクロールコンテナ */}
-          <main ref={parentRef} className="flex-1 overflow-auto"> {/* ref と overflow-auto を main に移動 */}
+      {/* pt-20 はヘッダー分 */}
+      <section className="flex-1 pt-20 pb-16"> {/* flex と overflow-hidden を削除 */}
+        {/* Table of Contents Sidebar - fixed positioning */}
+        <TableOfContents
+          sections={sectionsManifest}
+          className="hidden lg:block fixed top-20 left-0 w-64 h-[calc(100vh-5rem)] overflow-y-auto border-r border-border" /* fixed, left-0, w-64, border-r を追加 */
+        />
+        {/* Main Content Area - スクロールコンテナ */}
+        {/* container を削除し、main に直接 padding と margin を適用 */}
+        <main ref={parentRef} className="flex-1 overflow-auto lg:ml-64 px-4 md:px-6"> {/* lg:ml-64 と padding を追加 */}
             {/* 仮想化リストのコンテナ (HEAD) */}
             <div
               style={{
                 height: `${rowVirtualizer.getTotalSize()}px`,
-                width: '100%',
-                position: 'relative',
+                width: "100%",
+                position: "relative",
               }}
             >
               {loadingManifest && <div>目次を読み込み中...</div>}
-              {errorManifest && <div className="text-red-500">{errorManifest}</div>}
+              {errorManifest && (
+                <div className="text-red-500">{errorManifest}</div>
+              )}
               {/* 仮想化されたアイテムのレンダリング (HEAD) */}
               {rowVirtualizer.getVirtualItems().map((virtualItem) => {
                 const sectionInfo = sectionsManifest[virtualItem.index];
@@ -108,27 +115,31 @@ const Index = () => {
                   <div
                     key={sectionInfo.id}
                     ref={rowVirtualizer.measureElement} // レビューコメント対応
-                    data-index={virtualItem.index}      // レビューコメント対応
+                    data-index={virtualItem.index} // レビューコメント対応
                     style={{
-                      position: 'absolute',
+                      position: "absolute",
                       top: 0,
                       left: 0,
-                      width: '100%',
+                      width: "100%",
                       height: `${virtualItem.size}px`,
                       transform: `translateY(${virtualItem.start}px)`,
                     }}
                     id={sectionInfo.id}
                   >
                     {/* SectionLoader を使用 (HEAD), props 渡し修正済み */}
-                    <SectionLoader sectionId={sectionInfo.id} measureRef={rowVirtualizer.measureElement} index={virtualItem.index} />
+                    <SectionLoader
+                      sectionId={sectionInfo.id}
+                      measureRef={rowVirtualizer.measureElement}
+                      index={virtualItem.index}
+                    />
                   </div>
                 );
               })}
             </div>
           </main>
-        </div>
+        {/* この div は section の子要素である必要があった */}
+        {/* </div> */} {/* この div は不要 */}
       </section>
-
       {/* Footer */}
       {/* mt-auto を追加 (HEAD) */}
       <footer className="bg-secondary py-12 border-t border-border mt-auto">
@@ -148,7 +159,6 @@ const Index = () => {
           </div>
         </div>
       </footer>
-
       {/* Scroll to top button */}
       {/* onClick は parentRef を使う (HEAD) */}
       <button


### PR DESCRIPTION
## 変更内容

`package.json` の `scripts` セクションを修正し、`dev`、`build`、`build:dev` コマンドの実行前に `bundle-data` スクリプトが実行されるようにしました。

## 変更理由

開発サーバー起動時やビルド時にチートシートのセクションデータ (`public/data/sections`) とマニフェストファイル (`public/data/sections-manifest.json`) が生成されておらず、アプリケーションがマニフェストファイルを読み込めずに 404 エラーが発生していました。

この変更により、必要なデータファイルが常に最新の状態で生成されるようになり、エラーが解消されます。

## 関連 Issue

(もしあれば Issue 番号を記載)